### PR TITLE
rename getMessage -> getLoggableMessage

### DIFF
--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
@@ -22,7 +22,7 @@ import java.util.List;
 public interface SafeLoggable {
 
     /** The message, which is safe to log. */
-    String getLoggableMessage();
+    String getLogMessage();
 
     /** The arguments associated with the message. */
     List<Arg<?>> getArgs();

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
@@ -22,7 +22,7 @@ import java.util.List;
 public interface SafeLoggable {
 
     /** The message, which is safe to log. */
-    String getMessage();
+    String getLoggableMessage();
 
     /** The arguments associated with the message. */
     List<Arg<?>> getArgs();


### PR DESCRIPTION
@markelliot 

So I realized that having a method called `getMessage` overrides `Exception#getMessage`. I don't think we actually want these to be the same; we probably want `Exception#getMessage` to return the message + serialized args.

