### PR TITLE
Support for lazy arguments

### DIFF
--- a/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /** A wrapper around an argument used to build a formatted message. */
 public abstract class Arg<T> implements Serializable {
@@ -44,6 +45,10 @@ public abstract class Arg<T> implements Serializable {
 
     @Override
     public final String toString() {
+        if (value instanceof Supplier) {
+            Object lazyValue = ((Supplier) value).get();
+            return String.valueOf(lazyValue);
+        }
         return String.valueOf(value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
@@ -18,16 +18,20 @@ package com.palantir.logsafe;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /** A wrapper around an argument used to build a formatted message. */
 public abstract class Arg<T> implements Serializable {
 
     private final String name;
-    private final T value;
+    private final Supplier<T> lazyValue;
 
-    protected Arg(String name, T value) {
+    private boolean cached;
+    private T value;
+
+    protected Arg(String name, Supplier<T> lazyValue) {
         this.name = Objects.requireNonNull(name, "name may not be null");
-        this.value = value;
+        this.lazyValue = lazyValue;
     }
 
     /** A name describing this argument. */
@@ -36,15 +40,19 @@ public abstract class Arg<T> implements Serializable {
     }
 
     /** The value of this argument (which may be {@code null}). */
-    public final T getValue() {
-        return value;
+    public final synchronized T getValue() {
+        if (cached) {
+            return value;
+        }
+        cached = true;
+        return value = lazyValue.get();
     }
 
     public abstract boolean isSafeForLogging();
 
     @Override
     public final String toString() {
-        return String.valueOf(value);
+        return String.valueOf(getValue());
     }
 
     @Override
@@ -56,12 +64,12 @@ public abstract class Arg<T> implements Serializable {
             return false;
         }
         Arg<?> arg = (Arg<?>) other;
-        return Objects.equals(name, arg.name)
-                && Objects.equals(value, arg.value);
+        return Objects.equals(getName(), arg.getName())
+                && Objects.equals(getValue(), arg.getValue());
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(name, value);
+        return Objects.hash(getName(), getValue());
     }
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
@@ -18,20 +18,14 @@ package com.palantir.logsafe;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 /** A wrapper around an argument used to build a formatted message. */
 public abstract class Arg<T> implements Serializable {
 
     private final String name;
-    private final Supplier<T> lazyValue;
 
-    private boolean cached;
-    private T value;
-
-    protected Arg(String name, Supplier<T> lazyValue) {
+    protected Arg(String name) {
         this.name = Objects.requireNonNull(name, "name may not be null");
-        this.lazyValue = lazyValue;
     }
 
     /** A name describing this argument. */
@@ -40,15 +34,12 @@ public abstract class Arg<T> implements Serializable {
     }
 
     /** The value of this argument (which may be {@code null}). */
-    public final synchronized T getValue() {
-        if (cached) {
-            return value;
-        }
-        cached = true;
-        return value = lazyValue.get();
-    }
+    public abstract T getValue();
 
-    public abstract boolean isSafeForLogging();
+    /** returns true if this argument can be safely removed from a deployment. */
+    public boolean isSafeForLogging() {
+        return false;
+    }
 
     @Override
     public final String toString() {
@@ -72,4 +63,5 @@ public abstract class Arg<T> implements Serializable {
     public final int hashCode() {
         return Objects.hash(getName(), getValue());
     }
+
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/ConcreteArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/ConcreteArg.java
@@ -16,15 +16,17 @@
 
 package com.palantir.logsafe;
 
-import java.util.List;
+public class ConcreteArg<T> extends Arg<T> {
 
-/** An interface denoting a message that can be safely logged. */
-public interface SafeLoggable {
+    private final T value;
 
-    /** The message, which is safe to log. */
-    String getLogMessage();
+    ConcreteArg(String name, T value) {
+        super(name);
+        this.value = value;
+    }
 
-    /** The arguments associated with the message. */
-    List<ConcreteArg<?>> getArgs();
+    public final T getValue() {
+        return value;
+    }
 
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/LazyArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/LazyArg.java
@@ -16,15 +16,26 @@
 
 package com.palantir.logsafe;
 
-import java.util.List;
+import java.util.function.Supplier;
 
-/** An interface denoting a message that can be safely logged. */
-public interface SafeLoggable {
+public class LazyArg<T> extends Arg<T> {
 
-    /** The message, which is safe to log. */
-    String getLogMessage();
+    private final Supplier<T> lazyValue;
 
-    /** The arguments associated with the message. */
-    List<ConcreteArg<?>> getArgs();
+    private boolean cached;
+    private T value;
+
+    LazyArg(String name, Supplier<T> lazyValue) {
+        super(name);
+        this.lazyValue = lazyValue;
+    }
+
+    public final synchronized T getValue() {
+        if (cached) {
+            return value;
+        }
+        cached = true;
+        return value = lazyValue.get();
+    }
 
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/LazyArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/LazyArg.java
@@ -35,7 +35,8 @@ public class LazyArg<T> extends Arg<T> {
             return value;
         }
         cached = true;
-        return value = lazyValue.get();
+        value = lazyValue.get();
+        return value;
     }
 
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -16,15 +16,21 @@
 
 package com.palantir.logsafe;
 
+import java.util.function.Supplier;
+
 /** A wrapper around an argument known to be safe for logging. */
 public final class SafeArg<T> extends Arg<T> {
 
-    private SafeArg(String name, T value) {
-        super(name, value);
+    private SafeArg(String name, Supplier<T> lazyValue) {
+        super(name, lazyValue);
     }
 
     public static <T> SafeArg<T> of(String name, T value) {
-        return new SafeArg<>(name, value);
+        return new SafeArg<>(name, () -> value);
+    }
+
+    public static <T> SafeArg<T> of(String name, Supplier<T> lazyValue) {
+        return new SafeArg<>(name, lazyValue);
     }
 
     @Override

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -19,22 +19,36 @@ package com.palantir.logsafe;
 import java.util.function.Supplier;
 
 /** A wrapper around an argument known to be safe for logging. */
-public final class SafeArg<T> extends Arg<T> {
+public interface SafeArg {
 
-    private SafeArg(String name, Supplier<T> lazyValue) {
-        super(name, lazyValue);
+    final class Concrete<T> extends ConcreteArg<T> {
+        Concrete(String name, T value) {
+            super(name, value);
+        }
+
+        @Override
+        public boolean isSafeForLogging() {
+            return true;
+        }
     }
 
-    public static <T> SafeArg<T> of(String name, T value) {
-        return new SafeArg<>(name, () -> value);
+    final class Lazy<T> extends LazyArg<T> {
+        Lazy(String name, Supplier<T> lazyValue) {
+            super(name, lazyValue);
+        }
+
+        @Override
+        public boolean isSafeForLogging() {
+            return true;
+        }
     }
 
-    public static <T> SafeArg<T> of(String name, Supplier<T> lazyValue) {
-        return new SafeArg<>(name, lazyValue);
+    static <T> Arg<T> of(String name, T value) {
+        return new Concrete<>(name, value);
     }
 
-    @Override
-    public boolean isSafeForLogging() {
-        return true;
+    static <T> Arg<T> of(String name, Supplier<T> lazyValue) {
+        return new Lazy<>(name, lazyValue);
     }
+
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
@@ -25,6 +25,6 @@ public interface SafeLoggable {
     String getLogMessage();
 
     /** The arguments associated with the message. */
-    List<ConcreteArg<?>> getArgs();
+    List<Arg<?>> getArgs();
 
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -28,5 +28,5 @@ public interface UnsafeArg {
     static <T> Arg<T> of(String name, Supplier<T> lazyValue) {
         return new LazyArg<>(name, lazyValue);
     }
-    
+
 }

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -16,15 +16,21 @@
 
 package com.palantir.logsafe;
 
+import java.util.function.Supplier;
+
 /** A wrapper around an argument that is not safe for logging. */
 public final class UnsafeArg<T> extends Arg<T> {
 
-    private UnsafeArg(String name, T value) {
-        super(name, value);
+    private UnsafeArg(String name, Supplier<T> lazyValue) {
+        super(name, lazyValue);
     }
 
     public static <T> UnsafeArg<T> of(String name, T value) {
-        return new UnsafeArg<>(name, value);
+        return new UnsafeArg<>(name, () -> value);
+    }
+
+    public static <T> UnsafeArg<T> of(String name, Supplier<T> lazyValue) {
+        return new UnsafeArg<>(name, lazyValue);
     }
 
     @Override

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -19,23 +19,14 @@ package com.palantir.logsafe;
 import java.util.function.Supplier;
 
 /** A wrapper around an argument that is not safe for logging. */
-public final class UnsafeArg<T> extends Arg<T> {
+public interface UnsafeArg {
 
-    private UnsafeArg(String name, Supplier<T> lazyValue) {
-        super(name, lazyValue);
+    static <T> Arg<T> of(String name, T value) {
+        return new ConcreteArg<>(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(String name, T value) {
-        return new UnsafeArg<>(name, () -> value);
+    static <T> Arg<T> of(String name, Supplier<T> lazyValue) {
+        return new LazyArg<>(name, lazyValue);
     }
-
-    public static <T> UnsafeArg<T> of(String name, Supplier<T> lazyValue) {
-        return new UnsafeArg<>(name, lazyValue);
-    }
-
-    @Override
-    public boolean isSafeForLogging() {
-        return false;
-    }
-
+    
 }


### PR DESCRIPTION
Closes #8 

What do you think to something like this?  Then, instead of:
```
    if (logger.isDebugEnabled()) {
        logger.debug("Message {}", SafeArg.of("name", expensiveFunc()));
    }
```
I could do:
```
    logger.debug("Message {}", SafeArg.of("name", () -> expensiveFunc()));
```
Log4j 2 supports something similar, but slf4j are still talking about it.