### PR TITLE
[improvement] Add `@Nullable` annotation to checkNotNull method

### DIFF
--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -3,4 +3,5 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 dependencies {
     api project(':safe-logging')
     api 'com.google.errorprone:error_prone_annotations:2.1.3'
+    compileOnly 'com.google.code.findbugs:jsr305'
 }

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -22,6 +22,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import javax.annotation.Nullable;
 
 public final class Preconditions {
     private Preconditions() {}
@@ -181,7 +182,7 @@ public final class Preconditions {
      * @throws SafeNullPointerException if {@code reference} is null
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference) {
+    public static <T> T checkNotNull(@Nullable T reference) {
         if (reference == null) {
             throw new SafeNullPointerException();
         }
@@ -197,7 +198,7 @@ public final class Preconditions {
      * @throws SafeNullPointerException if {@code reference} is null
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference, String message) {
+    public static <T> T checkNotNull(@Nullable T reference, String message) {
         if (reference == null) {
             throw new SafeNullPointerException(message);
         }
@@ -210,7 +211,7 @@ public final class Preconditions {
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference, String message, Arg<?> arg) {
+    public static <T> T checkNotNull(@Nullable T reference, String message, Arg<?> arg) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg);
         }
@@ -223,7 +224,7 @@ public final class Preconditions {
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference, String message, Arg<?> arg1, Arg<?> arg2) {
+    public static <T> T checkNotNull(@Nullable T reference, String message, Arg<?> arg1, Arg<?> arg2) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg1, arg2);
         }
@@ -236,7 +237,7 @@ public final class Preconditions {
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference, String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public static <T> T checkNotNull(@Nullable T reference, String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg1, arg2, arg3);
         }
@@ -253,7 +254,7 @@ public final class Preconditions {
      * @throws SafeNullPointerException if {@code reference} is null
      */
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(T reference, String message, Arg<?>... args) {
+    public static <T> T checkNotNull(@Nullable T reference, String message, Arg<?>... args) {
         if (reference == null) {
             throw new SafeNullPointerException(message, args);
         }

--- a/versions.props
+++ b/versions.props
@@ -1,2 +1,3 @@
-org.assertj:assertj-core = 3.11.1
+com.google.code.findbugs:jsr305 = 3.0.2
 junit:junit = 4.12
+org.assertj:assertj-core = 3.11.1


### PR DESCRIPTION
## Before this PR

Uber's NullAway plugin would report false positives when you pass a possibly null variable to Preconditions.checkNotNull!!!

```
warning: [NullAway] passing @Nullable parameter 'VERSIONS.get(type)' where @NonNull is require
        return Preconditions.checkNotNull(VERSIONS.get(type), "Unable to get version", SafeArg.of("type", type));
                                                      ^
    (see http://t.uber.com/nullaway )
error: warnings found and -Werror specified
```

## After this PR

NullAway will understand that it's OK to pass possibly null things to this method, and the warning should go away.  The dependency is `compileOnly`, so it shouldn't be pulled in transitively.

https://github.com/palantir/gradle-baseline/issues/273