### PR TITLE
Add @Nullable annotations to Arg and subtypes

### DIFF
--- a/safe-logging/build.gradle
+++ b/safe-logging/build.gradle
@@ -1,1 +1,5 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
+
+dependencies {
+    compileOnly 'com.google.code.findbugs:jsr305'
+}

--- a/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Arg.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe;
 
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /** A wrapper around an argument used to build a formatted message. */
 public abstract class Arg<T> implements Serializable {
@@ -25,7 +26,7 @@ public abstract class Arg<T> implements Serializable {
     private final String name;
     private final T value;
 
-    protected Arg(String name, T value) {
+    protected Arg(String name, @Nullable T value) {
         this.name = Objects.requireNonNull(name, "name may not be null");
         this.value = value;
     }
@@ -36,6 +37,7 @@ public abstract class Arg<T> implements Serializable {
     }
 
     /** The value of this argument (which may be {@code null}). */
+    @Nullable
     public final T getValue() {
         return value;
     }

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -16,14 +16,16 @@
 
 package com.palantir.logsafe;
 
+import javax.annotation.Nullable;
+
 /** A wrapper around an argument known to be safe for logging. */
 public final class SafeArg<T> extends Arg<T> {
 
-    private SafeArg(String name, T value) {
+    private SafeArg(String name, @Nullable T value) {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(String name, T value) {
+    public static <T> SafeArg<T> of(String name, @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -16,14 +16,16 @@
 
 package com.palantir.logsafe;
 
+import javax.annotation.Nullable;
+
 /** A wrapper around an argument that is not safe for logging. */
 public final class UnsafeArg<T> extends Arg<T> {
 
-    private UnsafeArg(String name, T value) {
+    private UnsafeArg(String name, @Nullable T value) {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(String name, T value) {
+    public static <T> UnsafeArg<T> of(String name, @Nullable T value) {
         return new UnsafeArg<>(name, value);
     }
 


### PR DESCRIPTION
jsr305 is a compile-only dependency in order to provide a minimal
footprint while allowing validation in projects which provide the
dependency.