### PR TITLE
Annotate SafeArg/UnsafeArg name parameter with @CompileTimeConstant

### DIFF
--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -2,7 +2,6 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     api project(':safe-logging')
-    api 'com.google.errorprone:error_prone_annotations:2.1.3'
     compileOnly 'com.google.code.findbugs:jsr305'
 
     testImplementation 'junit:junit'

--- a/safe-logging/build.gradle
+++ b/safe-logging/build.gradle
@@ -1,1 +1,5 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
+
+dependencies {
+    api 'com.google.errorprone:error_prone_annotations'
+}

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -16,6 +16,7 @@
 
 package com.palantir.logsafe;
 
+import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument known to be safe for logging. */
@@ -25,7 +26,7 @@ public final class SafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(String name, @Nullable T value) {
+    public static <T> SafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -16,6 +16,7 @@
 
 package com.palantir.logsafe;
 
+import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument that is not safe for logging. */
@@ -25,7 +26,7 @@ public final class UnsafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(String name, @Nullable T value) {
+    public static <T> UnsafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
         return new UnsafeArg<>(name, value);
     }
 


### PR DESCRIPTION
This adds a dependency on error_prone_annotations to safe-logging,
previously only required by safe-logging preconditions.