### PR TITLE
Relax CompileTimeConstant constraint on SafeArg/UnsafeArg name

### DIFF
--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -2,6 +2,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 dependencies {
     api project(':safe-logging')
+    api 'com.google.errorprone:error_prone_annotations:2.1.3'
     compileOnly 'com.google.code.findbugs:jsr305'
 
     testImplementation 'junit:junit'

--- a/safe-logging/build.gradle
+++ b/safe-logging/build.gradle
@@ -1,5 +1,1 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
-
-dependencies {
-    api 'com.google.errorprone:error_prone_annotations'
-}

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -16,7 +16,6 @@
 
 package com.palantir.logsafe;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument known to be safe for logging. */
@@ -26,7 +25,7 @@ public final class SafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
+    public static <T> SafeArg<T> of(String name, @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -16,7 +16,6 @@
 
 package com.palantir.logsafe;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument that is not safe for logging. */
@@ -26,7 +25,7 @@ public final class UnsafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
+    public static <T> UnsafeArg<T> of(String name, @Nullable T value) {
         return new UnsafeArg<>(name, value);
     }
 


### PR DESCRIPTION
Revert "Annotate SafeArg/UnsafeArg name parameter with @CompileTimeConstant (#105)"

It's a relatively common use-case to provide dynamic names for SafeArg and UnsafeArg. Users have already classified the arg value as safe or unsafe so it is reasonable to assume they have properly considered the name as well.