### PR TITLE
[fix] UnsafeArg doesn't require CompileTimeConstant message

### DIFF
--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -16,7 +16,6 @@
 
 package com.palantir.logsafe;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument that is not safe for logging. */
@@ -26,7 +25,7 @@ public final class UnsafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
+    public static <T> UnsafeArg<T> of(String name, @Nullable T value) {
         return new UnsafeArg<>(name, value);
     }
 
@@ -34,5 +33,4 @@ public final class UnsafeArg<T> extends Arg<T> {
     public boolean isSafeForLogging() {
         return false;
     }
-
 }


### PR DESCRIPTION
Follow-up to https://github.com/palantir/safe-logging/pull/105

Adding `@CompileTimeConstant` has imposed quite a lot of work as people discover strange things they were doing with Args.

I think the original PR we were overly defensive, as our deployment infrastructure drops unsafe args completely, so in theory the names can be whatever you like!