### PR TITLE
[fix] relax @CompileTimeConstant requirement on SafeArg key

### DIFF
--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -3,6 +3,7 @@ apply from: "${rootDir}/gradle/publish-jar.gradle"
 dependencies {
     api project(':safe-logging')
     compileOnly 'com.google.code.findbugs:jsr305'
+    api 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'

--- a/safe-logging/build.gradle
+++ b/safe-logging/build.gradle
@@ -1,5 +1,1 @@
 apply from: "${rootDir}/gradle/publish-jar.gradle"
-
-dependencies {
-    api 'com.google.errorprone:error_prone_annotations'
-}

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -16,7 +16,6 @@
 
 package com.palantir.logsafe;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument known to be safe for logging. */
@@ -26,7 +25,7 @@ public final class SafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(@CompileTimeConstant String name, @Nullable T value) {
+    public static <T> SafeArg<T> of(String name, @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 


### PR DESCRIPTION
## Motivation

In 1.8.0 we started requiring `SafeArg.of(key, value)` to have a _compile time constant_ key. The intention was to prevent people wrapping unknown key-value pairs as SafeArgs, which would make it harder to CR and spot potential data leaks.

Since merging this, we've had a lot of complaints - particularly because it is _impossible to suppress the `CompileTimeStatic` check_.  This has caused problems for anyone who was dynamically constructing args, leading them to choose one of the following approaches:

1. just stop taking upgrades
2. add a line to versions.props to force safe-logging down to <1.8.0
3. obfuscate their codebase with a subclassed Arg hack:
```java
    /**
     * Like {@link SafeArg}, but works around strict {@link com.google.errorprone.annotations.CompileTimeConstant}
     * argument name restrictions.
     */
    private static final class DynamicSafeArg<T> extends Arg<T> {
        DynamicSafeArg(String name, @Nullable T value) {
            super(name, value);
        }
        @Override
        public boolean isSafeForLogging() {
            return true;
        }
    }
```

As far as we can tell, this annotation hasn't actually motivated people to replace dynamic usages with non-dynamic usages.

## Proposal

Google's error-prone maintainers carefully weigh the cost-benefit of introducing a new check vs the false positives and friction it causes. In this case, I think the friction outweighs the potential upside.

I'd propose turning this into a regular error-prone check, as part of baseline.  This would ensure that at the time new code is being written, people will get a warning if they dynamically construct SafeArgs and have to either rethink their approach or justify their suppression of this check.