### PR TITLE
[improvement] Report SafeException array argument values

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.logsafe.exceptions;
 
+import com.google.common.base.MoreObjects;
 import com.palantir.logsafe.Arg;
 
 /**
@@ -29,17 +30,10 @@ final class SafeExceptions {
             return message;
         }
 
-        StringBuilder builder = new StringBuilder();
-        builder.append(message).append(": {");
-        for (int i = 0; i < args.length; i++) {
-            Arg<?> arg = args[i];
-            if (i > 0) {
-                builder.append(", ");
-            }
-
-            builder.append(arg.getName()).append("=").append(arg.getValue());
+        MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper(message + ": ");
+        for (Arg<?> arg : args) {
+            builder.add(arg.getName(), arg.getValue());
         }
-        builder.append("}");
 
         return builder.toString();
     }

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -16,8 +16,8 @@
 
 package com.palantir.logsafe.exceptions;
 
-import com.google.common.base.MoreObjects;
 import com.palantir.logsafe.Arg;
+import java.util.Arrays;
 
 /**
  * {@link SafeExceptions} provides utility functionality for SafeLoggable exception implementations.
@@ -30,11 +30,30 @@ final class SafeExceptions {
             return message;
         }
 
-        MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper(message + ": ");
-        for (Arg<?> arg : args) {
-            builder.add(arg.getName(), arg.getValue());
+        StringBuilder builder = new StringBuilder();
+        builder.append(message).append(": {");
+        for (int i = 0; i < args.length; i++) {
+            Arg<?> arg = args[i];
+            if (i > 0) {
+                builder.append(", ");
+            }
+
+            builder.append(arg.getName()).append("=");
+            appendValue(builder, arg);
         }
+        builder.append('}');
 
         return builder.toString();
     }
+
+    private static void appendValue(StringBuilder builder, Arg<?> arg) {
+        Object value = arg.getValue();
+        if (value != null && value.getClass().isArray()) {
+            String arrayString = Arrays.deepToString(new Object[] {value});
+            builder.append(arrayString, 1, arrayString.length() - 1);
+        } else {
+            builder.append(value);
+        }
+    }
+
 }

--- a/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionTest.java
+++ b/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionTest.java
@@ -69,4 +69,17 @@ public class SafeExceptionTest {
         assertThat(exception.getMessage()).isEqualTo("Failure: {value=3, user=akarp}");
         assertThat(exception.getLogMessage()).isEqualTo("Failure");
     }
+
+    @Test
+    public void testArrayValues() {
+        SafeIllegalArgumentException exception = new SafeIllegalArgumentException(
+                "Failure",
+                SafeArg.of("value", 3),
+                SafeArg.of("strings", new String[] {"a", "b", "c"}),
+                UnsafeArg.of("ints", new int[] {1, 2}),
+                SafeArg.of("longs", new long[] {42, Integer.MAX_VALUE + 1L}));
+        assertThat(exception.getMessage())
+                .isEqualTo("Failure: {value=3, strings=[a, b, c], ints=[1, 2], longs=[42, 2147483648]}");
+        assertThat(exception.getLogMessage()).isEqualTo("Failure");
+    }
 }


### PR DESCRIPTION
## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

The message for a safe exception whose arg value is an array is an opaque string for the array's default `toString`.

For example
`new SafeIllegalArgumentException("message", SafeArg.of("array", new String[] {"a", "b"})).getMessage()` results in something like `"message: {array=[Ljava.lang.String;@a38d7a3}"`

## After this PR
<!-- Describe at a high-level why this approach is better. -->

Applies a deep `toString` to the safe exception's argument values that are arrays (both `Object[]` and primitive arrays).

Now `new SafeIllegalArgumentException("message", SafeArg.of("array", new String[] {"a", "b"})).getMessage()` results in something like `"message: {array=[a, b]}"`