### PR TITLE
[fix] Remove CompileTimeConstant from SafeIoException

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
@@ -16,7 +16,6 @@
 
 package com.palantir.logsafe.exceptions;
 
-import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
 import java.io.IOException;
@@ -28,13 +27,13 @@ public final class SafeIoException extends IOException implements SafeLoggable {
     private final String logMessage;
     private final List<Arg<?>> arguments;
 
-    public SafeIoException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIoException(String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIoException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+    public SafeIoException(String message, Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));


### PR DESCRIPTION
## Before this PR
We have safe messages that are not compile time constants but part of our api. We can't upgrade to new versions of the library because we're unable to change the messages without breaking our api.

## After this PR
Back to the original behavior that allows all messages, and will allow us to upgrade.