### PR TITLE
[improvement] Expose SafeExceptions.renderMessage publicly

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -22,10 +22,10 @@ import java.util.Arrays;
 /**
  * {@link SafeExceptions} provides utility functionality for SafeLoggable exception implementations.
  */
-final class SafeExceptions {
+public final class SafeExceptions {
     private SafeExceptions() {}
 
-    static String renderMessage(String message, Arg<?>... args) {
+    public static String renderMessage(String message, Arg<?>... args) {
         if (args.length == 0) {
             return message;
         }

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -16,6 +16,7 @@
 
 package com.palantir.logsafe.exceptions;
 
+import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import java.util.Arrays;
 
@@ -25,13 +26,13 @@ import java.util.Arrays;
 public final class SafeExceptions {
     private SafeExceptions() {}
 
-    public static String renderMessage(String message, Arg<?>... args) {
+    public static String renderMessage(@CompileTimeConstant String safeMessage, Arg<?>... args) {
         if (args.length == 0) {
-            return message;
+            return safeMessage;
         }
 
         StringBuilder builder = new StringBuilder();
-        builder.append(message).append(": {");
+        builder.append(safeMessage).append(": {");
         for (int i = 0; i < args.length; i++) {
             Arg<?> arg = args[i];
             if (i > 0) {


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Users implementing their own versions of SafeLoggable Exceptions (e.g. by extending existing Exception classes to make them SafeLoggable) need some way of rendering the message. Before this PR they would have to write their own versions of renderMessage() (or copy-paste).

## After this PR
<!-- Describe at a high-level why this approach is better. -->
This allows users to re-use the existing code, meaning greater maintainability and consistency. It makes sense that we should use the same patterns across the product.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
