### PR TITLE
Rename hasArgs to containsArgs

### DIFF
--- a/changelog/@unreleased/pr-176.v2.yml
+++ b/changelog/@unreleased/pr-176.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: LoggableExceptionAssert#hasArgs has been deprecated in favor of a new method LoggableExceptionAssert#containsArgs.
+  links:
+  - https://github.com/palantir/safe-logging/pull/176

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
@@ -54,6 +54,16 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
     }
 
     /**
+     * Deprecated in favor of {@link #containsArgs}.
+     *
+     * @deprecated use {@link #containsArgs}
+     */
+    @Deprecated
+    public final LoggableExceptionAssert<T> hasArgs(Arg<?>... args) {
+        return containsArgs(args);
+    }
+
+    /**
      * Verifies that the actual group contains the given values, in any order.
      *
      * @param args the given arguments.
@@ -64,7 +74,7 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
      * @throws AssertionError if the exception argument list is {@code null}.
      * @throws AssertionError if the exception does not contain the given arguments.
      */
-    public final LoggableExceptionAssert<T> hasArgs(Arg<?>... args) {
+    public final LoggableExceptionAssert<T> containsArgs(Arg<?>... args) {
         isNotNull();
 
         argsAssert.contains(args);

--- a/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableExceptionAssertionsTest.java
+++ b/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableExceptionAssertionsTest.java
@@ -50,7 +50,10 @@ public final class LoggableExceptionAssertionsTest {
                 .hasMessage("{index} must be less than {size}: {index=4, size=1}")
                 .hasLogMessage("{index} must be less than {size}")
                 .hasExactlyArgs(UnsafeArg.of("index", 4), SafeArg.of("size", 1))
-                .hasArgs(UnsafeArg.of("index", 4));
+                .hasArgs(UnsafeArg.of("index", 4))
+                .hasArgs(SafeArg.of("size", 1))
+                .containsArgs(UnsafeArg.of("index", 4))
+                .containsArgs(SafeArg.of("size", 1));
     }
 
     public void testNullPointerException(LoggableExceptionAssert<SafeNullPointerException> assertion) {
@@ -108,7 +111,7 @@ public final class LoggableExceptionAssertionsTest {
 
     public void testFailIllegalStateException(LoggableExceptionAssert<SafeIllegalStateException> assertion) {
         Arg<?> arg = SafeArg.of("missing", "missing");
-        assertThatThrownBy(() -> assertion.hasArgs(arg))
+        assertThatThrownBy(() -> assertion.containsArgs(arg))
                 .hasMessage(ShouldContain.shouldContain(
                         illegalStateException.getArgs(), Collections.singleton(arg), Collections.singleton(arg),
                         StandardComparisonStrategy.instance()).create());

--- a/safe-logging-refactorings/build.gradle
+++ b/safe-logging-refactorings/build.gradle
@@ -1,0 +1,6 @@
+apply from: "${rootDir}/gradle/publish-jar.gradle"
+
+dependencies {
+    implementation project(":preconditions-assertj")
+    implementation 'com.google.errorprone:error_prone_refaster'
+}

--- a/safe-logging-refactorings/src/main/java/com/palantir/logsafe/refactorings/DeprecatedLoggableExceptionAssertArgs.java
+++ b/safe-logging-refactorings/src/main/java/com/palantir/logsafe/refactorings/DeprecatedLoggableExceptionAssertArgs.java
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.logsafe.refactorings;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.testing.LoggableExceptionAssert;
+
+public final class DeprecatedLoggableExceptionAssertArgs<T extends Throwable & SafeLoggable> {
+
+    @BeforeTemplate
+    @SuppressWarnings("deprecation")
+    LoggableExceptionAssert<T> hasArgs(LoggableExceptionAssert<T> loggableExceptionAssert, Arg<?>... args) {
+        return loggableExceptionAssert.hasArgs(args);
+    }
+
+    @AfterTemplate
+    LoggableExceptionAssert<T> containsArgs(LoggableExceptionAssert<T> loggableExceptionAssert, Arg<?>... args) {
+        return loggableExceptionAssert.containsArgs(args);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'safe-logging'
 
 include 'safe-logging'
+include 'safe-logging-refactorings'
 include 'preconditions'
 include 'preconditions-assertj'
 

--- a/versions.props
+++ b/versions.props
@@ -6,3 +6,4 @@ org.assertj:assertj-core = 3.12.2
 
 org.checkerframework:checker-qual = 2.5.0
 com.google.errorprone:error_prone_annotations = 2.3.3
+com.google.errorprone:error_prone_refaster = 2.3.3


### PR DESCRIPTION
## Before this PR
`LoggableExceptionAssert#hasArgs` only checks whether the given args are contained in the actual args. The name of this method in misleading, as many users probably assume that the method checks that the args are exactly equal. This leads to weaker tests than users may have intended.

This is particularly confusing because [`ServiceExceptionAssert#hasArgs`](ServiceExceptionAssert) has the same name but does check that the args are exactly equal.

## After this PR
`LoggableExceptionAssert#hasArgs` is marked as deprecated in favor of a new method, ``LoggableExceptionAssert#containsArgs`. This should more clearly signal the behavior of this method to users.

This also more closely matches the naming convention of iterables asserts in AssertJ.