### PR TITLE
Fix refaster rule

### DIFF
--- a/changelog/@unreleased/pr-177.v2.yml
+++ b/changelog/@unreleased/pr-177.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix refaster rule for `hasArgs` -> `containsArgs` migration.
+  links:
+  - https://github.com/palantir/safe-logging/pull/177

--- a/safe-logging-refactorings/src/main/java/com/palantir/logsafe/refactorings/DeprecatedLoggableExceptionAssertArgs.java
+++ b/safe-logging-refactorings/src/main/java/com/palantir/logsafe/refactorings/DeprecatedLoggableExceptionAssertArgs.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.refactorings;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.testing.LoggableExceptionAssert;
@@ -26,12 +27,12 @@ public final class DeprecatedLoggableExceptionAssertArgs<T extends Throwable & S
 
     @BeforeTemplate
     @SuppressWarnings("deprecation")
-    LoggableExceptionAssert<T> hasArgs(LoggableExceptionAssert<T> loggableExceptionAssert, Arg<?>... args) {
+    LoggableExceptionAssert<T> hasArgs(LoggableExceptionAssert<T> loggableExceptionAssert, @Repeated Arg<?> args) {
         return loggableExceptionAssert.hasArgs(args);
     }
 
     @AfterTemplate
-    LoggableExceptionAssert<T> containsArgs(LoggableExceptionAssert<T> loggableExceptionAssert, Arg<?>... args) {
+    LoggableExceptionAssert<T> containsArgs(LoggableExceptionAssert<T> loggableExceptionAssert, @Repeated Arg<?> args) {
         return loggableExceptionAssert.containsArgs(args);
     }
 }


### PR DESCRIPTION
## Before this PR
Refaster rule didn't work because of https://github.com/google/error-prone/issues/568.

## After this PR
==COMMIT_MSG==
Fix refaster rule for hasArgs -> containsArgs migration.

A different syntax needed to be used when dealing with varargs, see related issue:
https://github.com/google/error-prone/issues/568
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

