### PR TITLE
Don't register representation using META-INF/services

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,0 +1,26 @@
+versionOverrides: {}
+acceptedBreaks:
+  1.11.0:
+    com.palantir.safe-logging:preconditions: []
+    com.palantir.safe-logging:preconditions-assertj:
+    - code: "java.class.nowFinal"
+      old: "class com.palantir.logsafe.testing.LoggableExceptionAssert<T extends java.lang.Throwable,\
+        \ com.palantir.logsafe.SafeLoggable>"
+      new: "class com.palantir.logsafe.testing.LoggableExceptionAssert<T extends java.lang.Throwable,\
+        \ com.palantir.logsafe.SafeLoggable>"
+      justification: "{Acceptable visibility reduction in loggable assertion classes}"
+    - code: "java.class.visibilityReduced"
+      old: "class com.palantir.logsafe.testing.LoggableArgRepresentation"
+      new: "class com.palantir.logsafe.testing.LoggableArgRepresentation"
+      justification: "{Acceptable visibility reduction in loggable assertion classes}"
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.logsafe.testing.LoggableArgRepresentation::<init>()"
+      new: "method void com.palantir.logsafe.testing.LoggableArgRepresentation::<init>()"
+      justification: "{Acceptable visibility reduction in loggable assertion classes}"
+    - code: "java.method.visibilityReduced"
+      old: "method void com.palantir.logsafe.testing.LoggableExceptionAssert<T extends\
+        \ java.lang.Throwable, com.palantir.logsafe.SafeLoggable>::<init>(T)"
+      new: "method void com.palantir.logsafe.testing.LoggableExceptionAssert<T extends\
+        \ java.lang.Throwable, com.palantir.logsafe.SafeLoggable>::<init>(T)"
+      justification: "{Acceptable visibility reduction in loggable assertion classes}"
+    com.palantir.safe-logging:safe-logging: []

--- a/changelog/@unreleased/pr-177.v2.yml
+++ b/changelog/@unreleased/pr-177.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Register LoggableArgRepresentation explicitly instead of using the deprecated service loading mechanism.
+  links:
+    - https://github.com/palantir/safe-logging/pull/188

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
@@ -31,24 +31,24 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static LoggableExceptionAssert<SafeIllegalArgumentException> assertThat(
             SafeIllegalArgumentException actual) {
-        return new LoggableExceptionAssert<>(actual);
+        return LoggableExceptionAssert.create(actual);
     }
 
     public static LoggableExceptionAssert<SafeIllegalStateException> assertThat(SafeIllegalStateException actual) {
-        return new LoggableExceptionAssert<>(actual);
+        return LoggableExceptionAssert.create(actual);
     }
 
     public static LoggableExceptionAssert<SafeNullPointerException> assertThat(SafeNullPointerException actual) {
-        return new LoggableExceptionAssert<>(actual);
+        return LoggableExceptionAssert.create(actual);
     }
 
     public static LoggableExceptionAssert<SafeIoException> assertThat(SafeIoException actual) {
-        return new LoggableExceptionAssert<>(actual);
+        return LoggableExceptionAssert.create(actual);
     }
 
     public static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> assertThatLoggableException(
             T actual) {
-        return new LoggableExceptionAssert<>(actual);
+        return LoggableExceptionAssert.create(actual);
     }
 
     @SuppressWarnings("unchecked")
@@ -59,6 +59,6 @@ public class Assertions extends org.assertj.core.api.Assertions {
                 .overridingErrorMessage(new BasicErrorMessageFactory("%nExpecting code to raise a throwable.").create())
                 .isNotNull();
         new ThrowableAssert(throwable).isInstanceOf(SafeLoggable.class);
-        return new LoggableExceptionAssert<>((T) throwable);
+        return LoggableExceptionAssert.create((T) throwable);
     }
 }

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableArgRepresentation.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableArgRepresentation.java
@@ -17,20 +17,25 @@
 package com.palantir.logsafe.testing;
 
 import com.palantir.logsafe.Arg;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 
-public class LoggableArgRepresentation extends StandardRepresentation  {
+final class LoggableArgRepresentation extends StandardRepresentation {
+
+    static final Representation INSTANCE = new LoggableArgRepresentation();
+
+    private LoggableArgRepresentation() {}
 
     @Override
-    protected final String fallbackToStringOf(Object object) {
+    protected String fallbackToStringOf(Object object) {
         if (object instanceof Arg) {
             Arg<?> arg = (Arg<?>) object;
-            return String.format("%s[%s=%s]",
+            return String.format(
+                    "%s[%s=%s]",
                     arg.getClass().getSimpleName(),
                     arg.getName(),
                     toStringOf(arg.getValue()));
         }
         return super.fallbackToStringOf(object);
     }
-
 }

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
@@ -24,11 +24,16 @@ import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.util.Objects;
 
-public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
+public final class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
         extends AbstractThrowableAssert<LoggableExceptionAssert<T>, T> {
     private final ArgsAssert argsAssert;
 
-    public LoggableExceptionAssert(T actual) {
+    static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> create(T actual) {
+        return new LoggableExceptionAssert<>(actual)
+                .withRepresentation(LoggableArgRepresentation.INSTANCE);
+    }
+
+    private LoggableExceptionAssert(T actual) {
         super(actual, LoggableExceptionAssert.class);
 
         List<Arg<?>> args = actual == null ? Collections.emptyList() : actual.getArgs();
@@ -44,9 +49,9 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
      * @throws AssertionError if the exception is {@code null}.
      * @throws AssertionError if the exception argument list is {@code null}.
      * @throws AssertionError if the exception arguments do not contain the given values, i.e. the exception contains
-     *           some or none of the given arguments, or the exception contains more arguments than the given ones.
+     * some or none of the given arguments, or the exception contains more arguments than the given ones.
      */
-    public final LoggableExceptionAssert<T> hasExactlyArgs(Arg<?>... args) {
+    public LoggableExceptionAssert<T> hasExactlyArgs(Arg<?>... args) {
         isNotNull();
 
         argsAssert.containsExactlyInAnyOrder(args);
@@ -59,7 +64,7 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
      * @deprecated use {@link #containsArgs}
      */
     @Deprecated
-    public final LoggableExceptionAssert<T> hasArgs(Arg<?>... args) {
+    public LoggableExceptionAssert<T> hasArgs(Arg<?>... args) {
         return containsArgs(args);
     }
 
@@ -74,14 +79,14 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
      * @throws AssertionError if the exception argument list is {@code null}.
      * @throws AssertionError if the exception does not contain the given arguments.
      */
-    public final LoggableExceptionAssert<T> containsArgs(Arg<?>... args) {
+    public LoggableExceptionAssert<T> containsArgs(Arg<?>... args) {
         isNotNull();
 
         argsAssert.contains(args);
         return this;
     }
 
-    public final LoggableExceptionAssert<T> hasLogMessage(String logMessage) {
+    public LoggableExceptionAssert<T> hasLogMessage(String logMessage) {
         isNotNull();
 
         String actualMessage = actual.getLogMessage();
@@ -90,10 +95,10 @@ public class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
                     logMessage, actualMessage));
         }
 
-        return myself;
+        return this;
     }
 
-    public final ArgsAssert args() {
+    public ArgsAssert args() {
         isNotNull();
 
         return argsAssert;

--- a/preconditions-assertj/src/main/resources/META-INF/services/org.assertj.core.presentation.Representation
+++ b/preconditions-assertj/src/main/resources/META-INF/services/org.assertj.core.presentation.Representation
@@ -1,1 +1,0 @@
-com.palantir.logsafe.testing.LoggableArgRepresentation

--- a/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableArgRepresentationTest.java
+++ b/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableArgRepresentationTest.java
@@ -25,26 +25,24 @@ import org.junit.Test;
 
 public class LoggableArgRepresentationTest {
 
-    private final LoggableArgRepresentation representation = new LoggableArgRepresentation();
-
     @Test
     public void toStringOf_safeArg() {
-        assertThat(representation.toStringOf(SafeArg.of("hello", "world")))
+        assertThat(LoggableArgRepresentation.INSTANCE.toStringOf(SafeArg.of("hello", "world")))
                 .isEqualTo("SafeArg[hello=\"world\"]");
     }
 
     @Test
     public void toStringOf_safeArg_complexType() {
         CompletableFuture<String> stringFuture = new CompletableFuture<>();
-        assertThat(representation.toStringOf(stringFuture)).isEqualTo("CompletableFuture[Incomplete]");
-        assertThat(representation.toStringOf(SafeArg.of("future", stringFuture)))
+        assertThat(LoggableArgRepresentation.INSTANCE.toStringOf(stringFuture)).isEqualTo(
+                "CompletableFuture[Incomplete]");
+        assertThat(LoggableArgRepresentation.INSTANCE.toStringOf(SafeArg.of("future", stringFuture)))
                 .isEqualTo("SafeArg[future=CompletableFuture[Incomplete]]");
     }
 
     @Test
     public void toStringOf_unsafeArg() {
-        assertThat(representation.toStringOf(UnsafeArg.of("hello", "world")))
+        assertThat(LoggableArgRepresentation.INSTANCE.toStringOf(UnsafeArg.of("hello", "world")))
                 .isEqualTo("UnsafeArg[hello=\"world\"]");
     }
-
 }

--- a/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableExceptionAssertionsTest.java
+++ b/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/LoggableExceptionAssertionsTest.java
@@ -161,7 +161,7 @@ public final class LoggableExceptionAssertionsTest {
 
     @Test
     public void nullArgsAssert() {
-        assertThatThrownBy(() -> new LoggableExceptionAssert<>(null).isNotNull())
+        assertThatThrownBy(() -> LoggableExceptionAssert.create(null).isNotNull())
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expecting actual not to be null");
     }


### PR DESCRIPTION
## Before this PR
Running tests using `preconditions-assertj` produces the following warning message:
```
Although it still works, registering a Representation through a file named 'org.assertj.core.presentation.Representation' in the META-INF/services directory is deprecated.
The proper way of providing a Representation is to register a Configuration as described in the documentation (a Configuration allowing to provide a Representation and other AssertJ configuration elements)
```

For more info, see https://assertj.github.io/doc/#assertj-core-representation.

## After this PR
Running tests using `preconditions-assertj` produces no warning messages.