### PR TITLE
Fix logsafe Preconditions usage example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Annotate Preconditions error messages with named `SafeArg` and `UnsafeArg` as ap
     // now
     import com.palantir.logsafe.Preconditions;
     ...
-    Preconditions.checkArgument(uname.size() > MAX_LEN, "{} username longer than max {}", 
+    Preconditions.checkArgument(uname.size() > MAX_LEN, "username longer than max",
             UnsafeArg.of("uname", uname), SafeArg.of("max", MAX_LEN));
 


### PR DESCRIPTION
## Before this PR
We recommended using a format that was not helpful.

Previous suggested formatting resulted in:
`{} username longer than max {}: {uname=world, max=3}`

## After this PR
Updated example results in:
`username longer than max: {uname=world, max=3}`
==COMMIT_MSG==
Fix logsafe Preconditions usage example in the readme
==COMMIT_MSG==

## Possible downsides?
None.

