### PR TITLE
Handle the ThrowableCallable not throwing an exception.

### DIFF
--- a/changelog/@unreleased/pr-257.v2.yml
+++ b/changelog/@unreleased/pr-257.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: If ThrowableCallable passed to Assertions.assertThatLoggableExceptionThrownBy
+    does not throw, appropriate message will be propagated.
+  links:
+  - https://github.com/palantir/safe-logging/pull/257

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
@@ -22,8 +22,9 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.Failures;
+import org.assertj.core.error.BasicErrorMessageFactory;
 
 public class Assertions extends org.assertj.core.api.Assertions {
     Assertions() {}
@@ -54,10 +55,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
     public static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> assertThatLoggableExceptionThrownBy(
             ThrowingCallable shouldRaiseThrowable) {
         Throwable throwable = AssertionsForClassTypes.catchThrowable(shouldRaiseThrowable);
-        if (!SafeLoggable.class.isInstance(throwable)) {
-            throw Failures.instance().failure(String.format("Expecting code to throw a SafeLoggable exception, "
-                    + "but caught a %s which does not", throwable.getClass().getCanonicalName()));
-        }
+        new ThrowableAssert(throwable)
+                .overridingErrorMessage(new BasicErrorMessageFactory("%nExpecting code to raise a throwable.").create())
+                .isNotNull();
+        new ThrowableAssert(throwable).isInstanceOf(SafeLoggable.class);
         return new LoggableExceptionAssert<>((T) throwable);
     }
 }

--- a/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/AssertionsTest.java
+++ b/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/AssertionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.logsafe.testing;
+
+import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
+
+import com.palantir.logsafe.SafeLoggable;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ShouldBeInstance;
+import org.junit.Test;
+
+public final class AssertionsTest {
+
+    @Test
+    public void testCodeDoesNotThrowException() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> assertThatLoggableExceptionThrownBy(() -> { }))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage(new BasicErrorMessageFactory("%nExpecting code to raise a throwable.").create());
+    }
+
+    @Test
+    public void testCodeThrowsNotSafeLoggable() {
+        RuntimeException exception = new RuntimeException("Oops");
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> assertThatLoggableExceptionThrownBy(() -> {
+            throw exception;
+        })).isExactlyInstanceOf(AssertionError.class)
+                .hasMessage(ShouldBeInstance.shouldBeInstance(exception, SafeLoggable.class).create());
+    }
+
+    @Test
+    public void testCodeThrowsSafeLoggable() {
+        assertThatLoggableExceptionThrownBy(() -> {
+            throw new SafeIllegalStateException("Hello");
+        });
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Currently this code just throws NullPointerException when trying to get the type of exception thrown.

## After this PR
==COMMIT_MSG==
If ThrowableCallable passed to Assertions.assertThatLoggableExceptionThrownBy does not throw, appropriate message will be propagated.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

