### PR TITLE
Annotate preconditions-assertj Assertions with CheckReturnValue

### DIFF
--- a/changelog/@unreleased/pr-316.v2.yml
+++ b/changelog/@unreleased/pr-316.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Annotate preconditions-assertj Assertions with CheckReturnValue to
+    match assertj-core.
+  links:
+  - https://github.com/palantir/safe-logging/pull/316

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
@@ -23,7 +23,10 @@ import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.CanIgnoreReturnValue;
+import org.assertj.core.util.CheckReturnValue;
 
+@CheckReturnValue
 public class Assertions extends org.assertj.core.api.Assertions {
     Assertions() {}
 
@@ -49,6 +52,7 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return LoggableExceptionAssert.create(actual);
     }
 
+    @CanIgnoreReturnValue
     public static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> assertThatLoggableExceptionThrownBy(
             ThrowingCallable shouldRaiseThrowable) {
         return assertThatThrownBy(shouldRaiseThrowable)


### PR DESCRIPTION
The `@CheckReturnValue` annotation is not inherited from the
superclass.

==COMMIT_MSG==
Annotate preconditions-assertj Assertions with CheckReturnValue to match assertj-core.
==COMMIT_MSG==

