### PR TITLE
Don't impose error-prone-annotations 2.3.4 on users

### DIFF
--- a/changelog/@unreleased/pr-321.v2.yml
+++ b/changelog/@unreleased/pr-321.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`com.palantir.safe-logging:preconditions` no longer imposes the `error_prone_annotations`
+    jar on consumers classpaths'
+  links:
+  - https://github.com/palantir/safe-logging/pull/321

--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.palantir.revapi'
 dependencies {
     api project(':safe-logging')
     compileOnly 'com.google.code.findbugs:jsr305'
-    api 'com.google.errorprone:error_prone_annotations'
+    compileOnly 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'junit:junit'
     testImplementation 'org.assertj:assertj-core'


### PR DESCRIPTION
## Before this PR

We got auto-upgraded to error_prone_annotations 2.3.4, and this means that pretty much any repo using safe-logging transitively gets this version of the annotations.

Unfortunately, there seems to be a bug in baseline whereby if it finds a new version of the annotations on the classpath (2.3.4), it will try and use a _matching_ version of the compiler.  This is now blocking WC upgrades across the fleet because a bunch of people haven't updated their baseline past https://github.com/palantir/gradle-baseline/releases/tag/2.38.0.

## After this PR
==COMMIT_MSG==
`com.palantir.safe-logging:preconditions` no longer imposes the `error_prone_annotations` jar on consumers classpaths
==COMMIT_MSG==

I've done a pTML and tried this on WC and everything compiled fine as the annotations were already present.

I _think_ this should also be fine if a consumer doesn't have the annotations.

## Possible downsides?

<!-- Please describe any way users could be negatively affected by this PR. -->

