### PR TITLE
Annotate Preconditions.checkNotNull with `@Nonnull`

### DIFF
--- a/changelog/@unreleased/pr-337.v2.yml
+++ b/changelog/@unreleased/pr-337.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotate Preconditions.checkNotNull with `@Nonnull`
+  links:
+  - https://github.com/palantir/safe-logging/pull/337

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -23,6 +23,7 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class Preconditions {
@@ -185,6 +186,7 @@ public final class Preconditions {
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference) {
         if (reference == null) {
@@ -201,6 +203,7 @@ public final class Preconditions {
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message) {
         if (reference == null) {
@@ -214,6 +217,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
         if (reference == null) {
@@ -227,6 +231,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
             @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
@@ -241,6 +246,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
             @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -259,6 +265,7 @@ public final class Preconditions {
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {
         if (reference == null) {


### PR DESCRIPTION
We generally assume all non-null by default, however this library
is used widely across our codebases incluging legacy components
which cannot assume non-null by default. In these environments
it's helpful for IDEs and static analysis tooling if we explicitly
annotate checkNotNull methods.

We could annotate the class (or package) with
`ParametersAreNonnullByDefault`, but we've found support varies
between tools.

## Before this PR
Some tools assume the result of Preconditions.checkNotNull(value) could be null.

## After this PR
==COMMIT_MSG==
Annotate Preconditions.checkNotNull with `@Nonnull`
==COMMIT_MSG==

## Possible downsides?
no.

