### PR TITLE
SafeLoggable exception message rendering no longer fails on null args

### DIFF
--- a/changelog/@unreleased/pr-492.v2.yml
+++ b/changelog/@unreleased/pr-492.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: SafeLoggable exception message rendering no longer fails on null args
+  links:
+  - https://github.com/palantir/safe-logging/pull/492

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -25,20 +25,24 @@ public final class SafeExceptions {
     private SafeExceptions() {}
 
     public static String renderMessage(@CompileTimeConstant String safeMessage, Arg<?>... args) {
-        if (args.length == 0) {
+        if (args == null || args.length == 0) {
             return safeMessage;
         }
 
         StringBuilder builder = new StringBuilder();
         builder.append(safeMessage).append(": {");
-        for (int i = 0; i < args.length; i++) {
-            Arg<?> arg = args[i];
-            if (i > 0) {
-                builder.append(", ");
-            }
+        boolean first = true;
+        for (Arg<?> arg : args) {
+            if (arg != null) {
+                if (!first) {
+                    builder.append(", ");
+                } else {
+                    first = false;
+                }
 
-            builder.append(arg.getName()).append("=");
-            appendValue(builder, arg);
+                builder.append(arg.getName()).append("=");
+                appendValue(builder, arg);
+            }
         }
         builder.append('}');
 

--- a/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionsTest.java
+++ b/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionsTest.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.logsafe.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
+import org.junit.Test;
+
+public final class SafeExceptionsTest {
+
+    @Test
+    public void testRenderContainsNullArg() {
+        String rendered = SafeExceptions.renderMessage("test", SafeArg.of("a", "b"), null, UnsafeArg.of("c", "d"));
+        assertThat(rendered).isEqualTo("test: {a=b, c=d}");
+    }
+
+    @Test
+    public void testRenderNullArgs() {
+        String rendered = SafeExceptions.renderMessage("test", (Arg<?>[]) null);
+        assertThat(rendered).isEqualTo("test");
+    }
+
+    @Test
+    public void testRenderNullMessage() {
+        String rendered = SafeExceptions.renderMessage(null, SafeArg.of("a", "b"));
+        assertThat(rendered).isEqualTo("null: {a=b}");
+    }
+}


### PR DESCRIPTION
## Before this PR
The render method threw a NPE when an argument value was null. This exception destroys our ability to capture the root cause -- we must either set the original as a cause/suppressed-cause or provide as much data as possible.

It's clearly not ideal to have null arg values, however it's even worse if we're unable to diagnose the original problem based on logging, so we mustn't be opinionated here.

## After this PR

==COMMIT_MSG==
SafeLoggable exception message rendering no longer fails on null args
==COMMIT_MSG==

## Possible downsides?
none.

