### PR TITLE
Add @Unsafe annotation as inverse of @Safe

### DIFF
--- a/changelog/@unreleased/pr-498.v2.yml
+++ b/changelog/@unreleased/pr-498.v2.yml
@@ -1,5 +1,5 @@
 type: feature
-fix:
+feature:
   description: Add @Unsafe annotation as inverse of @Safe
   links:
   - https://github.com/palantir/safe-logging/pull/498

--- a/changelog/@unreleased/pr-498.v2.yml
+++ b/changelog/@unreleased/pr-498.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+fix:
+  description: Add @Unsafe annotation as inverse of @Safe
+  links:
+  - https://github.com/palantir/safe-logging/pull/498

--- a/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter on a Jersey resource to be safe.
+ * Marks a parameter on a resource to be safe.
  *
  * <p>Example:
  *

--- a/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a parameter on a Jersey resource to be unsafe.
+ * Explicitly marks a parameter as unsafe.
  *
  * <p>Inverse of {@link Safe}.
  */

--- a/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2017 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.logsafe;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a parameter on a Jersey resource to be unsafe.
+ *
+ * <p>Inverse of {@link Safe}.
+ */
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Unsafe {}


### PR DESCRIPTION
## Before this PR
Currently only the `@Safe` annotation exists within the `com.palantir.logsafe` package. In some cases it is not sufficient to assume that the absence of an `@Safe` annotation on a parameter implies that it is unsafe. This PR adds the inverse of that annotation, providing users the capability to explicitly mark a parameter as unsafe.

## After this PR
==COMMIT_MSG==
Add @Unsafe annotation as inverse of @Safe
==COMMIT_MSG==

## Possible downsides?
Additional surface area that is initially only used in limited circumstances.