### PR TITLE
`Throwable` parameters are annotated `@Nullable`

### DIFF
--- a/changelog/@unreleased/pr-569.v2.yml
+++ b/changelog/@unreleased/pr-569.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`Throwable` parameters are annotated `@Nullable`'
+  links:
+  - https://github.com/palantir/safe-logging/pull/569

--- a/logger-generator/build.gradle
+++ b/logger-generator/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation project(':safe-logging')
     implementation 'com.google.errorprone:error_prone_annotations'
+    implementation 'com.google.code.findbugs:jsr305'
     implementation 'com.squareup:javapoet'
     implementation 'com.palantir.goethe:goethe'
 }

--- a/logger-generator/src/main/java/com/palantir/logsafe/logger/generator/LoggerGenerator.java
+++ b/logger-generator/src/main/java/com/palantir/logsafe/logger/generator/LoggerGenerator.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
 
@@ -141,6 +142,7 @@ public final class LoggerGenerator {
 
             ParameterSpec throwableParameter = ParameterSpec.builder(THROWABLE_TYPE, THROWABLE_NAME)
                     .addJavadoc("Throwable to log with a stack trace\n")
+                    .addAnnotation(Nullable.class)
                     .build();
 
             for (int i = 0; i <= 10; i++) {

--- a/logger-slf4j/build.gradle
+++ b/logger-slf4j/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':logger-spi')
-    implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'org.slf4j:slf4j-api'
-
+    implementation 'com.google.errorprone:error_prone_annotations'
+    compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'com.google.auto.service:auto-service-annotations'
     annotationProcessor 'com.google.auto.service:auto-service'
 }

--- a/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
+++ b/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
@@ -18,6 +18,7 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.logger.spi.SafeLoggerBridge;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -56,7 +57,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, throwable);
     }
 
@@ -75,7 +76,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, arg0, throwable);
     }
 
@@ -94,7 +95,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, throwable);
         }
@@ -117,7 +118,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void trace(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -146,7 +148,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, throwable);
         }
@@ -177,7 +179,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, throwable);
         }
@@ -215,7 +217,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
         }
@@ -255,7 +257,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
         }
@@ -297,7 +299,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
         }
@@ -341,7 +343,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
         }
@@ -387,7 +389,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
         }
@@ -412,7 +414,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, merge(args, throwable));
         }
@@ -441,7 +443,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, throwable);
     }
 
@@ -460,7 +462,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, arg0, throwable);
     }
 
@@ -479,7 +481,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, throwable);
         }
@@ -502,7 +504,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void debug(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -531,7 +534,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, throwable);
         }
@@ -562,7 +565,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, throwable);
         }
@@ -600,7 +603,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
         }
@@ -640,7 +643,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
         }
@@ -682,7 +685,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
         }
@@ -726,7 +729,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
         }
@@ -772,7 +775,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
         }
@@ -797,7 +800,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, merge(args, throwable));
         }
@@ -826,7 +829,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, throwable);
     }
 
@@ -845,7 +848,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, arg0, throwable);
     }
 
@@ -864,7 +867,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, throwable);
         }
@@ -887,7 +890,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void info(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -916,7 +920,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, throwable);
         }
@@ -947,7 +951,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, throwable);
         }
@@ -985,7 +989,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
         }
@@ -1025,7 +1029,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
         }
@@ -1067,7 +1071,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
         }
@@ -1111,7 +1115,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
         }
@@ -1157,7 +1161,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
         }
@@ -1182,7 +1186,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, merge(args, throwable));
         }
@@ -1211,7 +1215,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, throwable);
     }
 
@@ -1230,7 +1234,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, arg0, throwable);
     }
 
@@ -1249,7 +1253,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, throwable);
         }
@@ -1272,7 +1276,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void warn(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -1301,7 +1306,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, throwable);
         }
@@ -1332,7 +1337,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, throwable);
         }
@@ -1370,7 +1375,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
         }
@@ -1410,7 +1415,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
         }
@@ -1452,7 +1457,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
         }
@@ -1496,7 +1501,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
         }
@@ -1542,7 +1547,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
         }
@@ -1567,7 +1572,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, merge(args, throwable));
         }
@@ -1596,7 +1601,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, throwable);
     }
 
@@ -1615,7 +1620,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, arg0, throwable);
     }
 
@@ -1634,7 +1639,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, throwable);
         }
@@ -1657,7 +1662,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void error(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -1686,7 +1692,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, throwable);
         }
@@ -1717,7 +1723,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, throwable);
         }
@@ -1755,7 +1761,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
         }
@@ -1795,7 +1801,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
         }
@@ -1837,7 +1843,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
         }
@@ -1881,7 +1887,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
         }
@@ -1927,7 +1933,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
         }
@@ -1952,7 +1958,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, merge(args, throwable));
         }

--- a/logger-spi/build.gradle
+++ b/logger-spi/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':safe-logging')
-    api 'com.google.errorprone:error_prone_annotations'
+    implementation 'com.google.errorprone:error_prone_annotations'
+    compileOnly 'com.google.code.findbugs:jsr305'
 }
 
 sourceCompatibility = 11

--- a/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
+++ b/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
@@ -16,6 +16,7 @@ package com.palantir.logsafe.logger.spi;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -41,7 +42,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, Throwable throwable);
+    void trace(@CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -54,7 +55,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable);
+    void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -67,7 +68,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable);
+    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -80,7 +81,8 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable);
+    void trace(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -99,7 +101,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -119,7 +121,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -147,7 +149,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -177,7 +179,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -209,7 +211,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -243,7 +245,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -279,7 +281,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -294,7 +296,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable);
+    void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /**
      * Returns {@code true} if the {@code debug} level is enabled.
@@ -312,7 +314,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, Throwable throwable);
+    void debug(@CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -325,7 +327,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable);
+    void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -338,7 +340,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable);
+    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -351,7 +353,8 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable);
+    void debug(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -370,7 +373,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -390,7 +393,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -418,7 +421,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -448,7 +451,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -480,7 +483,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -514,7 +517,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -550,7 +553,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -565,7 +568,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable);
+    void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /**
      * Returns {@code true} if the {@code info} level is enabled.
@@ -583,7 +586,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, Throwable throwable);
+    void info(@CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -596,7 +599,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable);
+    void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -609,7 +612,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable);
+    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -622,7 +625,8 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable);
+    void info(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -641,7 +645,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -661,7 +665,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -689,7 +693,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -719,7 +723,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -751,7 +755,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -785,7 +789,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -821,7 +825,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -836,7 +840,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable);
+    void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /**
      * Returns {@code true} if the {@code warn} level is enabled.
@@ -854,7 +858,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, Throwable throwable);
+    void warn(@CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -867,7 +871,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable);
+    void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -880,7 +884,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable);
+    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -893,7 +897,8 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable);
+    void warn(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -912,7 +917,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -932,7 +937,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -960,7 +965,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -990,7 +995,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1022,7 +1027,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1056,7 +1061,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1092,7 +1097,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1107,7 +1112,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable);
+    void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /**
      * Returns {@code true} if the {@code error} level is enabled.
@@ -1125,7 +1130,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, Throwable throwable);
+    void error(@CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1138,7 +1143,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable);
+    void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1151,7 +1156,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable);
+    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1164,7 +1169,8 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable);
+    void error(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1183,7 +1189,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1203,7 +1209,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1231,7 +1237,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1261,7 +1267,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1293,7 +1299,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1327,7 +1333,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1363,7 +1369,7 @@ public interface SafeLoggerBridge {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable);
+            @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1378,5 +1384,5 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable);
+    void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 }

--- a/logger/build.gradle
+++ b/logger/build.gradle
@@ -3,8 +3,9 @@ apply plugin: 'com.palantir.revapi'
 
 dependencies {
     api project(':safe-logging')
-    api 'com.google.errorprone:error_prone_annotations'
     implementation project(':logger-spi')
+    implementation 'com.google.errorprone:error_prone_annotations'
+    compileOnly 'com.google.code.findbugs:jsr305'
     runtimeOnly project(':logger-slf4j')
 }
 

--- a/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
+++ b/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
@@ -18,6 +18,7 @@ import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.logger.spi.SafeLoggerBridge;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
@@ -55,7 +56,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.trace(message, throwable);
     }
 
@@ -72,7 +73,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.trace(message, arg0, throwable);
     }
 
@@ -89,7 +90,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, throwable);
     }
 
@@ -106,7 +107,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void trace(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, throwable);
     }
 
@@ -129,7 +131,7 @@ public final class SafeLogger {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, throwable);
     }
 
@@ -154,7 +156,7 @@ public final class SafeLogger {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, throwable);
     }
 
@@ -186,7 +188,7 @@ public final class SafeLogger {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
     }
 
@@ -220,7 +222,7 @@ public final class SafeLogger {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
     }
 
@@ -256,7 +258,7 @@ public final class SafeLogger {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
     }
 
@@ -294,7 +296,7 @@ public final class SafeLogger {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
     }
 
@@ -334,7 +336,7 @@ public final class SafeLogger {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
     }
 
@@ -353,7 +355,7 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.trace(message, args, throwable);
     }
 
@@ -377,7 +379,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.debug(message, throwable);
     }
 
@@ -394,7 +396,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.debug(message, arg0, throwable);
     }
 
@@ -411,7 +413,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, throwable);
     }
 
@@ -428,7 +430,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void debug(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, throwable);
     }
 
@@ -451,7 +454,7 @@ public final class SafeLogger {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, throwable);
     }
 
@@ -476,7 +479,7 @@ public final class SafeLogger {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, throwable);
     }
 
@@ -508,7 +511,7 @@ public final class SafeLogger {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
     }
 
@@ -542,7 +545,7 @@ public final class SafeLogger {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
     }
 
@@ -578,7 +581,7 @@ public final class SafeLogger {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
     }
 
@@ -616,7 +619,7 @@ public final class SafeLogger {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
     }
 
@@ -656,7 +659,7 @@ public final class SafeLogger {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
     }
 
@@ -675,7 +678,7 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.debug(message, args, throwable);
     }
 
@@ -699,7 +702,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.info(message, throwable);
     }
 
@@ -716,7 +719,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.info(message, arg0, throwable);
     }
 
@@ -733,7 +736,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, throwable);
     }
 
@@ -750,7 +753,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void info(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, throwable);
     }
 
@@ -773,7 +777,7 @@ public final class SafeLogger {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, throwable);
     }
 
@@ -798,7 +802,7 @@ public final class SafeLogger {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, throwable);
     }
 
@@ -830,7 +834,7 @@ public final class SafeLogger {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
     }
 
@@ -864,7 +868,7 @@ public final class SafeLogger {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
     }
 
@@ -900,7 +904,7 @@ public final class SafeLogger {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
     }
 
@@ -938,7 +942,7 @@ public final class SafeLogger {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
     }
 
@@ -978,7 +982,7 @@ public final class SafeLogger {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
     }
 
@@ -997,7 +1001,7 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.info(message, args, throwable);
     }
 
@@ -1021,7 +1025,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.warn(message, throwable);
     }
 
@@ -1038,7 +1042,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.warn(message, arg0, throwable);
     }
 
@@ -1055,7 +1059,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, throwable);
     }
 
@@ -1072,7 +1076,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void warn(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, throwable);
     }
 
@@ -1095,7 +1100,7 @@ public final class SafeLogger {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, throwable);
     }
 
@@ -1120,7 +1125,7 @@ public final class SafeLogger {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, throwable);
     }
 
@@ -1152,7 +1157,7 @@ public final class SafeLogger {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
     }
 
@@ -1186,7 +1191,7 @@ public final class SafeLogger {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
     }
 
@@ -1222,7 +1227,7 @@ public final class SafeLogger {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
     }
 
@@ -1260,7 +1265,7 @@ public final class SafeLogger {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
     }
 
@@ -1300,7 +1305,7 @@ public final class SafeLogger {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
     }
 
@@ -1319,7 +1324,7 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.warn(message, args, throwable);
     }
 
@@ -1343,7 +1348,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.error(message, throwable);
     }
 
@@ -1360,7 +1365,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.error(message, arg0, throwable);
     }
 
@@ -1377,7 +1382,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, throwable);
     }
 
@@ -1394,7 +1399,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Throwable throwable) {
+    public void error(
+            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, throwable);
     }
 
@@ -1417,7 +1423,7 @@ public final class SafeLogger {
             Arg<?> arg1,
             Arg<?> arg2,
             Arg<?> arg3,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, throwable);
     }
 
@@ -1442,7 +1448,7 @@ public final class SafeLogger {
             Arg<?> arg2,
             Arg<?> arg3,
             Arg<?> arg4,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, throwable);
     }
 
@@ -1474,7 +1480,7 @@ public final class SafeLogger {
             Arg<?> arg3,
             Arg<?> arg4,
             Arg<?> arg5,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, arg5, throwable);
     }
 
@@ -1508,7 +1514,7 @@ public final class SafeLogger {
             Arg<?> arg4,
             Arg<?> arg5,
             Arg<?> arg6,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, throwable);
     }
 
@@ -1544,7 +1550,7 @@ public final class SafeLogger {
             Arg<?> arg5,
             Arg<?> arg6,
             Arg<?> arg7,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, throwable);
     }
 
@@ -1582,7 +1588,7 @@ public final class SafeLogger {
             Arg<?> arg6,
             Arg<?> arg7,
             Arg<?> arg8,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, throwable);
     }
 
@@ -1622,7 +1628,7 @@ public final class SafeLogger {
             Arg<?> arg7,
             Arg<?> arg8,
             Arg<?> arg9,
-            Throwable throwable) {
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, throwable);
     }
 
@@ -1641,7 +1647,7 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, Throwable throwable) {
+    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.error(message, args, throwable);
     }
 }


### PR DESCRIPTION
## Before this PR
This prevents issues in projects which enforce `NullAway`.
Nullable exceptions for debugging based on some predicate
are relatively common. This impacts us because we often
configure nullaway to enforce with the `com.palantir`
prefix which covers `com.palantir.logsafe.logger` but not
`org.slf4j`.

Issue discovered here:
https://github.com/palantir/dialogue/pull/1340

## After this PR
==COMMIT_MSG==
`Throwable` parameters are annotated `@Nullable`
==COMMIT_MSG==

