### PR TITLE
Add checkArgumentNotNull method

### DIFF
--- a/changelog/@unreleased/pr-571.v2.yml
+++ b/changelog/@unreleased/pr-571.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Adds a `checkArgumentNotNull` method that is similar to `checkNotNull`
+    but throws `SafeIllegalArgumentException` instead.
+  links:
+  - https://github.com/palantir/safe-logging/pull/571

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -115,6 +115,102 @@ public final class Preconditions {
     }
 
     /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference an String reference
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalArgumentException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(@Nullable T reference) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException();
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference an String reference
+     * @param message the loggable exception message
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalArgumentException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkArgumentNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message, arg);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkArgumentNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(
+            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message, arg1, arg2);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkArgumentNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(
+            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message, arg1, arg2, arg3);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference an String reference
+     * @param message the loggable exception message
+     * @param args the arguments to include in the {@link SafeIllegalArgumentException}
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalArgumentException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkArgumentNotNull(
+            @Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message, args);
+        }
+        return reference;
+    }
+
+    /**
      * Ensures the truth of an expression involving the state of the calling instance, but not involving any parameters
      * to the calling method.
      *


### PR DESCRIPTION
I frequently find myself wanting a method like `checkNotNull` but that throws a `SafeIllegalArgumentException` instead so it manifests as a 400 response.

Currently, this requires code like:
```java
Foo getFoo() {
    Foo foo = computeFoo();
    checkArgument(foo != null, ...);
    return foo;
}
```

But it would be nice if I could write:
```java
Foo getFoo() {
    return checkArgumentNotNull(computeFoo(), ...)
}
```

This PR adds a `checkArgumentNotNull` that checks if the given argument is null, returns it if it is not null, and throws a `SafeIllegalArgumentException` otherwise.