### PR TITLE
preconditions-assertj applies a global representation for `Arg`

### DIFF
--- a/changelog/@unreleased/pr-671.v2.yml
+++ b/changelog/@unreleased/pr-671.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: preconditions-assertj applies a global representation for `Arg`
+  links:
+  - https://github.com/palantir/safe-logging/pull/671

--- a/preconditions-assertj/build.gradle
+++ b/preconditions-assertj/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     api project(':safe-logging')
     api 'org.assertj:assertj-core'
 
+    compileOnly 'com.google.auto.service:auto-service-annotations'
+    annotationProcessor 'com.google.auto.service:auto-service'
+
     testImplementation 'junit:junit'
 }
 

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableArgRepresentation.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableArgRepresentation.java
@@ -16,15 +16,21 @@
 
 package com.palantir.logsafe.testing;
 
+import com.google.auto.service.AutoService;
 import com.palantir.logsafe.Arg;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 
-final class LoggableArgRepresentation extends StandardRepresentation {
+/**
+ * A {@link Representation} implementation which includes the {@link Arg} {@link Class#getSimpleName()},
+ * {@link Arg#getName()}, and {@link Arg#getValue()}.
+ */
+@AutoService(Representation.class)
+public final class LoggableArgRepresentation extends StandardRepresentation {
 
     static final Representation INSTANCE = new LoggableArgRepresentation();
 
-    private LoggableArgRepresentation() {}
+    public LoggableArgRepresentation() {}
 
     @Override
     protected String fallbackToStringOf(Object object) {

--- a/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/AssertionsTest.java
+++ b/preconditions-assertj/src/test/java/com/palantir/logsafe/testing/AssertionsTest.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.testing;
 
 import static com.palantir.logsafe.testing.Assertions.assertThatLoggableExceptionThrownBy;
 
+import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.SafeLoggable;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import org.assertj.core.error.BasicErrorMessageFactory;
@@ -49,5 +50,15 @@ public final class AssertionsTest {
         assertThatLoggableExceptionThrownBy(() -> {
             throw new SafeIllegalStateException("Hello");
         });
+    }
+
+    @Test
+    public void testCodeThrowsSafeLoggableWithArgUsesCorrectRepresentation() {
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> assertThatLoggableExceptionThrownBy(() -> {
+                            throw new SafeIllegalStateException("Hello", SafeArg.of("c", "d"));
+                        })
+                        .hasExactlyArgs(SafeArg.of("a", "b")))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContainingAll("[SafeArg[a=\"b\"]]", "[SafeArg[c=\"d\"]]");
     }
 }


### PR DESCRIPTION
==COMMIT_MSG==
preconditions-assertj applies a global representation for `Arg`
==COMMIT_MSG==

