### PR TITLE
Add a `@DoNotLog` annotation. Existing annotations apply to types/methods

### DIFF
--- a/changelog/@unreleased/pr-674.v2.yml
+++ b/changelog/@unreleased/pr-674.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Add a `@DoNotLog` annotation to describe types which mustn't be logged.
+    Existing `@Safe` and `@Unsafe` annotations can be applied to types and methods
+    to more expressively describe element safety. Subclasses inherit safe-logging
+    annotations from parents.
+  links:
+  - https://github.com/palantir/safe-logging/pull/674

--- a/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
@@ -24,40 +24,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks an element as safe.
- *
- * <p>Example:
- *
- * <pre><code>
- *  import com.palantir.logsafe.Safe;
- *  import javax.ws.rs.Get;
- *  import javax.ws.rs.Path;
- *  import javax.ws.rs.PathParam;
- *
- * {@literal @}Path("/foo")
- *  public interface Foo {
- *     {@literal @}GET
- *     {@literal @}Path("/bar/{baz}/{bop}")
- *      void doSomething(
- *          {@literal @}Safe @PathParam("baz") String baz,
- *          {@literal @}PathParam("bop") String bop);
- *  }
- * </code></pre>
- *
- * If you sent a request to this server that looked like <code>/foo/bar/hello/world</code>, then an implementation which
- * relies on these annotations <i>must</i> guarantee that <code>hello</code> will be preserved and <code>world</code>
- * will not be preserved.
- *
- * <p>An example output could look like one of these example:
- *
- * <ul>
- *   <li><code>/foo/bar/hello/_REDACTED_</code>
- *   <li><code>/foo/bar/hello/{bop}</code>
- *   <li><code>/foo/bar/hello/A7F386C91</code>
- * </ul>
+ * Marks elements that should never be logged.
+ * For example, credentials, keys, and other secrets cannot be logged because such an action would compromise security.
  */
 @Documented
 @Inherited
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Safe {}
+public @interface DoNotLog {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -25,7 +25,7 @@ public final class SafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(String name, @Nullable T value) {
+    public static <T> SafeArg<T> of(String name, @Safe @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
@@ -18,16 +18,18 @@ package com.palantir.logsafe;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Explicitly marks a parameter as unsafe.
+ * Explicitly marks an element as unsafe.
  *
  * <p>Inverse of {@link Safe}.
  */
 @Documented
-@Target(ElementType.PARAMETER)
+@Inherited
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Unsafe {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -25,7 +25,7 @@ public final class UnsafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(String name, @Nullable T value) {
+    public static <T> UnsafeArg<T> of(String name, @Nullable @Unsafe T value) {
         return new UnsafeArg<>(name, value);
     }
 


### PR DESCRIPTION
## Before this PR
No way to describe types that cannot be logged via safe-logging annotations.
No way to describe the safety of a method return value
No way to describe the safety of a type.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add a `@DoNotLog` annotation to describe types which mustn't be logged. Existing `@Safe` and `@Unsafe` annotations can be applied to types and methods to more expressively describe element safety. Subclasses inherit safe-logging annotations from parents.
==COMMIT_MSG==