### PR TITLE
safe-logging annotations may be applied to fields and variables

### DIFF
--- a/changelog/@unreleased/pr-682.v2.yml
+++ b/changelog/@unreleased/pr-682.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: safe-logging annotations may be applied to fields and variables
+  links:
+  - https://github.com/palantir/safe-logging/pull/682

--- a/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
@@ -29,6 +29,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DoNotLog {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
@@ -58,6 +58,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Safe {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
@@ -30,6 +30,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Unsafe {}


### PR DESCRIPTION
This allows us to assert each assignment agrees with the annotated
type, and allows us to trust that field/variable level is correct
based on the aforementioned validation.

==COMMIT_MSG==
safe-logging annotations may be applied to fields and variables
==COMMIT_MSG==

