### PR TITLE
Allow annotations on type use (`List<@Safe String>`)

### DIFF
--- a/changelog/@unreleased/pr-699.v2.yml
+++ b/changelog/@unreleased/pr-699.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow annotations on type use (`List<@Safe String>`)
+  links:
+  - https://github.com/palantir/safe-logging/pull/699

--- a/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/DoNotLog.java
@@ -29,6 +29,13 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.FIELD,
+    ElementType.TYPE_USE
+})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DoNotLog {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Safe.java
@@ -58,6 +58,13 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.FIELD,
+    ElementType.TYPE_USE
+})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Safe {}

--- a/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/Unsafe.java
@@ -30,6 +30,13 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Inherited
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.FIELD})
+@Target({
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.PARAMETER,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.FIELD,
+    ElementType.TYPE_USE
+})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Unsafe {}


### PR DESCRIPTION
==COMMIT_MSG==
Allow annotations on type use (`List<@Safe String>`)
==COMMIT_MSG==

See examples of enforcement in https://github.com/palantir/gradle-baseline/pull/2187 Tests in particular: https://github.com/palantir/gradle-baseline/pull/2187/files#diff-9f39cf8d659f98e8e09abd4dff1235eb049a8b030370988a6c77d886d3f48bca

```java
    @Test
    public void testUnsafeTypeParameterProvidesSafety() {
        helper().addSourceLines(
                        "Test.java",
                        "import com.palantir.logsafe.*;",
                        "import java.util.*;",
                        "class Test {",
                        "  void f(List<@Unsafe String> input) {",
                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
                                + "but the parameter requires 'SAFE'.",
                        "    fun(input.get(0));",
                        "  }",
                        "  private static void fun(@Safe Object obj) {}",
                        "}")
                .doTest();
    }
```
and
```java
    @Test
    public void testUnsafeTypeParameterConsumesSafety() {
        helper().addSourceLines(
                        "Test.java",
                        "import com.palantir.logsafe.*;",
                        "import java.util.*;",
                        "class Test {",
                        "  void f(List<@Safe String> collection, @Unsafe String data) {",
                        "    // BUG: Diagnostic contains: Dangerous argument value: arg is 'UNSAFE' "
                                + "but the parameter requires 'SAFE'.",
                        "    collection.add(data);",
                        "  }",
                        "}")
                .doTest();
    }
```