### PR TITLE
SafeLoggable.getLogMessage is annotated as `@Safe`

### DIFF
--- a/changelog/@unreleased/pr-742.v2.yml
+++ b/changelog/@unreleased/pr-742.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: SafeLoggable.getLogMessage is annotated as `@Safe`
+  links:
+  - https://github.com/palantir/safe-logging/pull/742

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -19,6 +19,7 @@ package com.palantir.logsafe;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument known to be safe for logging. */
+@Safe
 public final class SafeArg<T> extends Arg<T> {
 
     private SafeArg(String name, @Nullable T value) {

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeLoggable.java
@@ -22,6 +22,7 @@ import java.util.List;
 public interface SafeLoggable {
 
     /** The message, which is safe to log. */
+    @Safe
     String getLogMessage();
 
     /** The arguments associated with the message. */

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -19,6 +19,7 @@ package com.palantir.logsafe;
 import javax.annotation.Nullable;
 
 /** A wrapper around an argument that is not safe for logging. */
+@Unsafe
 public final class UnsafeArg<T> extends Arg<T> {
 
     private UnsafeArg(String name, @Nullable T value) {


### PR DESCRIPTION
No difference in practice, just allows annotations to reinforce documentation/spec.
==COMMIT_MSG==
SafeLoggable.getLogMessage is annotated as `@Safe`
==COMMIT_MSG==

