### PR TITLE
Rev the major version to avoid matching ambiguous patterns

### DIFF
--- a/changelog/@unreleased/pr-758.v2.yml
+++ b/changelog/@unreleased/pr-758.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Rev the major version to avoid matching ambiguous patterns
+  links:
+  - https://github.com/palantir/safe-logging/pull/758


### PR DESCRIPTION
==COMMIT_MSG==
Rev the major version to avoid matching ambiguous patterns
==COMMIT_MSG==

