### PR TITLE
Preconditions provide contract information for static analysis

### DIFF
--- a/changelog/@unreleased/pr-784.v2.yml
+++ b/changelog/@unreleased/pr-784.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Preconditions provide contract information for static analysis
+  links:
+  - https://github.com/palantir/safe-logging/pull/784

--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.palantir.revapi'
 dependencies {
     api project(':safe-logging')
     compileOnly 'com.google.code.findbugs:jsr305'
+    implementation 'org.jetbrains:annotations'
     api 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'junit:junit'

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -36,6 +36,7 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.Contract;
 
 public final class Preconditions {
     private Preconditions() {}
@@ -46,6 +47,7 @@ public final class Preconditions {
      * @param expression a boolean expression
      * @throws SafeIllegalArgumentException if {@code expression} is false
      */
+    @Contract("false -> fail")
     public static void checkArgument(boolean expression) {
         if (!expression) {
             throw new SafeIllegalArgumentException();
@@ -56,9 +58,10 @@ public final class Preconditions {
      * Ensures the truth of an expression involving one or more parameters to the calling method.
      *
      * @param expression a boolean expression
-     * @param message the loggable exception message
+     * @param message    the loggable exception message
      * @throws SafeIllegalArgumentException if {@code expression} is false
      */
+    @Contract("false, _ -> fail")
     public static void checkArgument(boolean expression, @CompileTimeConstant String message) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message);
@@ -70,6 +73,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _ -> fail")
     public static void checkArgument(boolean expression, @CompileTimeConstant String message, Arg<?> arg) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, arg);
@@ -81,6 +85,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _, _ -> fail")
     public static void checkArgument(
             boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (!expression) {
@@ -93,6 +98,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _, _, _ -> fail")
     public static void checkArgument(
             boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
@@ -104,10 +110,11 @@ public final class Preconditions {
      * Ensures the truth of an expression involving one or more parameters to the calling method.
      *
      * @param expression a boolean expression
-     * @param message the loggable exception message
-     * @param args the arguments to include in the {@link SafeIllegalArgumentException}
+     * @param message    the loggable exception message
+     * @param args       the arguments to include in the {@link SafeIllegalArgumentException}
      * @throws SafeIllegalArgumentException if {@code expression} is false
      */
+    @Contract("false, _, _ -> fail")
     public static void checkArgument(boolean expression, @CompileTimeConstant String message, Arg<?>... args) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, args);
@@ -123,6 +130,7 @@ public final class Preconditions {
      */
     @Nonnull
     @CanIgnoreReturnValue
+    @Contract("null -> fail; !null -> param1")
     public static <T> T checkArgumentNotNull(@Nullable T reference) {
         if (reference == null) {
             throw new SafeIllegalArgumentException();
@@ -134,12 +142,13 @@ public final class Preconditions {
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
      * @param reference an String reference
-     * @param message the loggable exception message
+     * @param message   the loggable exception message
      * @return the non-null reference that was validated
      * @throws SafeIllegalArgumentException if {@code reference} is null
      */
     @Nonnull
     @CanIgnoreReturnValue
+    @Contract("null, _ -> fail; !null, _ -> param1")
     public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message);
@@ -152,6 +161,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkArgumentNotNull(Object, String, Arg...)} for details.
      */
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
@@ -168,6 +178,7 @@ public final class Preconditions {
      */
     @Nonnull
     @CanIgnoreReturnValue
+    @Contract("null, _, _, _ -> fail; !null, _, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
             @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (reference == null) {
@@ -183,6 +194,7 @@ public final class Preconditions {
      */
     @Nonnull
     @CanIgnoreReturnValue
+    @Contract("null, _, _, _, _ -> fail; !null, _, _, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
             @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (reference == null) {
@@ -195,13 +207,14 @@ public final class Preconditions {
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
      * @param reference an String reference
-     * @param message the loggable exception message
-     * @param args the arguments to include in the {@link SafeIllegalArgumentException}
+     * @param message   the loggable exception message
+     * @param args      the arguments to include in the {@link SafeIllegalArgumentException}
      * @return the non-null reference that was validated
      * @throws SafeIllegalArgumentException if {@code reference} is null
      */
     @Nonnull
     @CanIgnoreReturnValue
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
             @Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {
         if (reference == null) {
@@ -217,6 +230,7 @@ public final class Preconditions {
      * @param expression a boolean expression
      * @throws SafeIllegalStateException if {@code expression} is false
      */
+    @Contract("false -> fail")
     public static void checkState(boolean expression) {
         if (!expression) {
             throw new SafeIllegalStateException();
@@ -228,9 +242,10 @@ public final class Preconditions {
      * to the calling method.
      *
      * @param expression a boolean expression
-     * @param message the loggable exception message
+     * @param message    the loggable exception message
      * @throws SafeIllegalStateException if {@code expression} is false
      */
+    @Contract("false, _ -> fail")
     public static void checkState(boolean expression, @CompileTimeConstant String message) {
         if (!expression) {
             throw new SafeIllegalStateException(message);
@@ -242,6 +257,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _ -> fail")
     public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?> arg) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg);
@@ -253,6 +269,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _, _ -> fail")
     public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg1, arg2);
@@ -264,6 +281,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
+    @Contract("false, _, _, _, _ -> fail")
     public static void checkState(
             boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
@@ -276,10 +294,11 @@ public final class Preconditions {
      * to the calling method.
      *
      * @param expression a boolean expression
-     * @param message the loggable exception message
-     * @param args the arguments to include in the {@link SafeIllegalStateException}
+     * @param message    the loggable exception message
+     * @param args       the arguments to include in the {@link SafeIllegalStateException}
      * @throws SafeIllegalStateException if {@code expression} is false
      */
+    @Contract("false, _, _ -> fail")
     public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?>... args) {
         if (!expression) {
             throw new SafeIllegalStateException(message, args);
@@ -293,6 +312,7 @@ public final class Preconditions {
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Contract("null -> fail; !null -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference) {
@@ -306,10 +326,11 @@ public final class Preconditions {
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
      * @param reference an String reference
-     * @param message the loggable exception message
+     * @param message   the loggable exception message
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Contract("null, _ -> fail; !null, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message) {
@@ -324,6 +345,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
@@ -338,6 +360,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Contract("null, _, _, _ -> fail; !null, _, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
@@ -353,6 +376,7 @@ public final class Preconditions {
      *
      * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
      */
+    @Contract("null, _, _, _, _ -> fail; !null, _, _, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
@@ -367,11 +391,12 @@ public final class Preconditions {
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
      * @param reference an String reference
-     * @param message the loggable exception message
-     * @param args the arguments to include in the {@link SafeNullPointerException}
+     * @param message   the loggable exception message
+     * @param args      the arguments to include in the {@link SafeNullPointerException}
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {

--- a/versions.lock
+++ b/versions.lock
@@ -5,6 +5,7 @@ com.google.errorprone:error_prone_annotations:2.11.0 (4 constraints: 25338d4f)
 com.palantir.goethe:goethe:0.8.0 (1 constraints: 0a050336)
 com.squareup:javapoet:1.13.0 (2 constraints: 2b113eee)
 org.apache.logging.log4j:log4j-api:2.19.0 (1 constraints: 3e054a3b)
+org.jetbrains:annotations:23.0.0 (1 constraints: 37053c3b)
 org.slf4j:slf4j-api:1.7.31 (1 constraints: 3e05463b)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,7 @@ com.google.guava:guava = 31.1-jre
 com.uber.nullaway:nullaway = 0.10.2
 junit:junit = 4.13.2
 org.assertj:assertj-core = 3.23.1
+org.jetbrains:annotations = 23.0.0
 org.checkerframework:checker-qual = 3.25.0
 com.squareup:javapoet = 1.13.0
 com.palantir.goethe:goethe = 0.8.0


### PR DESCRIPTION
This is helpful for IDE analysis using jebrains IDEs, but I implemented this primarily because [NullAway supports the `@Contract` annotation](https://github.com/uber/NullAway/wiki/Supported-Annotations#contracts) which are recommended for first party code over implementing [custom library models](https://github.com/uber/NullAway/wiki/Configuration#library-models)
==COMMIT_MSG==
Preconditions provide contract information for static analysis
==COMMIT_MSG==

### Future Work

I'd also like to add contract information to our generated conjure error utilities.