### PR TITLE
Preconditions org.jetbrains:annotations should be api dep

### DIFF
--- a/preconditions/build.gradle
+++ b/preconditions/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.palantir.revapi'
 dependencies {
     api project(':safe-logging')
     compileOnly 'com.google.code.findbugs:jsr305'
-    implementation 'org.jetbrains:annotations'
+    api 'org.jetbrains:annotations'
     api 'com.google.errorprone:error_prone_annotations'
 
     testImplementation 'junit:junit'


### PR DESCRIPTION
## Before this PR
Some projects that depended on safe-logging:preconditions are failing to upgrade automatically because they cannot find this dep.

`(/com/palantir/logsafe/Preconditions.class): warning: Cannot find annotation method 'value()' in type 'Contract': class file for org.jetbrains.annotations.Contract not found`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

