### PR TITLE
Add SafeLoggable SafeUnsupportedOperationException

### DIFF
--- a/changelog/@unreleased/pr-860.v2.yml
+++ b/changelog/@unreleased/pr-860.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add SafeLoggable SafeUnsupportedOperationException
+  links:
+  - https://github.com/palantir/safe-logging/pull/860

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.logsafe.exceptions;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.SafeLoggable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class SafeUnsupportedOperationException extends UnsupportedOperationException implements SafeLoggable {
+    private final String logMessage;
+    private final List<Arg<?>> arguments;
+
+    public SafeUnsupportedOperationException() {
+        super("");
+        this.logMessage = "";
+        this.arguments = Collections.emptyList();
+    }
+
+    public SafeUnsupportedOperationException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        super(SafeExceptions.renderMessage(message, arguments));
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+    }
+
+    public SafeUnsupportedOperationException(
+            @CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+    }
+
+    public SafeUnsupportedOperationException(Throwable cause) {
+        super("", cause);
+        this.logMessage = "";
+        this.arguments = Collections.emptyList();
+    }
+
+    @Override
+    public String getLogMessage() {
+        return logMessage;
+    }
+
+    @Override
+    public List<Arg<?>> getArgs() {
+        return arguments;
+    }
+}


### PR DESCRIPTION
Since we've just added a SafeUncheckedIoException, let's add a safe-loggable variant of UnsupportedOperationException as well. This way after letting versions upgrade for a time, we can automate replacing non-safelogging variants in one fell swoop.
==COMMIT_MSG==
Add SafeLoggable SafeUnsupportedOperationException
==COMMIT_MSG==

