### PR TITLE
Add `@Nullable` annotations to exception causes

### DIFF
--- a/changelog/@unreleased/pr-869.v2.yml
+++ b/changelog/@unreleased/pr-869.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add `@Nullable` annotations to exception causes
+  links:
+  - https://github.com/palantir/safe-logging/pull/869

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
@@ -22,6 +22,7 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeIllegalArgumentException extends IllegalArgumentException implements SafeLoggable {
     private final String logMessage;
@@ -39,13 +40,14 @@ public final class SafeIllegalArgumentException extends IllegalArgumentException
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIllegalArgumentException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+    public SafeIllegalArgumentException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIllegalArgumentException(Throwable cause) {
+    public SafeIllegalArgumentException(@Nullable Throwable cause) {
         super("", cause);
         this.logMessage = "";
         this.arguments = Collections.emptyList();

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
@@ -22,6 +22,7 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeIllegalStateException extends IllegalStateException implements SafeLoggable {
     private final String logMessage;
@@ -39,13 +40,14 @@ public final class SafeIllegalStateException extends IllegalStateException imple
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIllegalStateException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+    public SafeIllegalStateException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIllegalStateException(Throwable cause) {
+    public SafeIllegalStateException(@Nullable Throwable cause) {
         super("", cause);
         this.logMessage = "";
         this.arguments = Collections.emptyList();

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeIoException extends IOException implements SafeLoggable {
     private final String logMessage;
@@ -34,7 +35,7 @@ public final class SafeIoException extends IOException implements SafeLoggable {
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIoException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+    public SafeIoException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
@@ -22,6 +22,7 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeRuntimeException extends RuntimeException implements SafeLoggable {
     private final String logMessage;
@@ -39,13 +40,13 @@ public final class SafeRuntimeException extends RuntimeException implements Safe
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeRuntimeException(@CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+    public SafeRuntimeException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeRuntimeException(Throwable cause) {
+    public SafeRuntimeException(@Nullable Throwable cause) {
         super("", cause);
         this.logMessage = "";
         this.arguments = Collections.emptyList();

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
@@ -24,18 +24,20 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeUncheckedIoException extends UncheckedIOException implements SafeLoggable {
     private final String logMessage;
     private final List<Arg<?>> arguments;
 
-    public SafeUncheckedIoException(@CompileTimeConstant String message, IOException cause, Arg<?>... arguments) {
+    public SafeUncheckedIoException(
+            @CompileTimeConstant String message, @Nullable IOException cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeUncheckedIoException(IOException cause) {
+    public SafeUncheckedIoException(@Nullable IOException cause) {
         super("", cause);
         this.logMessage = "";
         this.arguments = Collections.emptyList();

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
@@ -22,6 +22,7 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public final class SafeUnsupportedOperationException extends UnsupportedOperationException implements SafeLoggable {
     private final String logMessage;
@@ -40,13 +41,13 @@ public final class SafeUnsupportedOperationException extends UnsupportedOperatio
     }
 
     public SafeUnsupportedOperationException(
-            @CompileTimeConstant String message, Throwable cause, Arg<?>... arguments) {
+            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeUnsupportedOperationException(Throwable cause) {
+    public SafeUnsupportedOperationException(@Nullable Throwable cause) {
         super("", cause);
         this.logMessage = "";
         this.arguments = Collections.emptyList();


### PR DESCRIPTION
## Before this PR
Baseline's nullaway plugin blocks calling these constructors with a `null` cause:

```
 warning: [NullAway] passing @Nullable parameter 'last' where @NonNull is required
        throw new SafeRuntimeException("Unable to execute call even after exponential backoff.", last);
                                                                                                 ^
    (see http://t.uber.com/nullaway )
error: warnings found and -Werror specified
```

But null causes are explicitly allowed in the JDK for this parameter: 

https://github.com/openjdk/jdk/blob/46c4da7fddb8103934f2a90b4456a5ce6ed3467c/src/java.base/share/classes/java/lang/Exception.java#L79-L81

So we need to tell nullaway that this pattern is nullable, and the standard way to do that is with the `javax.annotation.Nullable` annotation.

## After this PR
==COMMIT_MSG==
Add `@Nullable` annotations to exception causes
==COMMIT_MSG==