### PR TITLE
Check in changes to generated source files

### DIFF
--- a/logger-log4j/src/main/java/com/palantir/logsafe/logger/log4j/Log4jSafeLoggerBridge.java
+++ b/logger-log4j/src/main/java/com/palantir/logsafe/logger/log4j/Log4jSafeLoggerBridge.java
@@ -34,9 +34,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
         this.delegate = Objects.requireNonNull(delegate, "Log4j Logger is required");
     }
 
-    /**
-     * Returns {@code true} if the {@code trace} level is enabled.
-     */
+    /** Returns {@code true} if the {@code trace} level is enabled. */
     @Override
     public boolean isTraceEnabled() {
         return delegate.isTraceEnabled(MARKER);
@@ -44,6 +42,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -53,6 +52,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -63,6 +63,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -72,6 +73,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -82,6 +84,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -91,6 +94,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -101,6 +105,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -110,6 +115,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -121,6 +127,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -130,6 +137,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -146,6 +154,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -156,6 +165,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -173,6 +183,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -189,6 +200,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -207,6 +219,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -224,6 +237,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -243,6 +257,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -261,6 +276,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -281,6 +297,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -300,6 +317,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -321,6 +339,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -341,6 +360,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -365,6 +385,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -377,6 +398,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -388,9 +410,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code debug} level is enabled.
-     */
+    /** Returns {@code true} if the {@code debug} level is enabled. */
     @Override
     public boolean isDebugEnabled() {
         return delegate.isDebugEnabled(MARKER);
@@ -398,6 +418,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -407,6 +428,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -417,6 +439,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -426,6 +449,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -436,6 +460,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -445,6 +470,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -455,6 +481,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -464,6 +491,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -475,6 +503,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -484,6 +513,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -500,6 +530,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -510,6 +541,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -527,6 +559,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -543,6 +576,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -561,6 +595,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -578,6 +613,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -597,6 +633,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -615,6 +652,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -635,6 +673,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -654,6 +693,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -675,6 +715,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -695,6 +736,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -719,6 +761,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -731,6 +774,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -742,9 +786,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code info} level is enabled.
-     */
+    /** Returns {@code true} if the {@code info} level is enabled. */
     @Override
     public boolean isInfoEnabled() {
         return delegate.isInfoEnabled(MARKER);
@@ -752,6 +794,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -761,6 +804,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -771,6 +815,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -780,6 +825,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -790,6 +836,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -799,6 +846,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -809,6 +857,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -818,6 +867,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -829,6 +879,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -838,6 +889,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -854,6 +906,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -864,6 +917,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -881,6 +935,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -897,6 +952,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -915,6 +971,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -932,6 +989,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -951,6 +1009,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -969,6 +1028,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -989,6 +1049,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1008,6 +1069,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1029,6 +1091,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1049,6 +1112,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1073,6 +1137,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1085,6 +1150,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1096,9 +1162,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code warn} level is enabled.
-     */
+    /** Returns {@code true} if the {@code warn} level is enabled. */
     @Override
     public boolean isWarnEnabled() {
         return delegate.isWarnEnabled(MARKER);
@@ -1106,6 +1170,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1115,6 +1180,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1125,6 +1191,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1134,6 +1201,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1144,6 +1212,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1153,6 +1222,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1163,6 +1233,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1172,6 +1243,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1183,6 +1255,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1192,6 +1265,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1208,6 +1282,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1218,6 +1293,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1235,6 +1311,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1251,6 +1328,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1269,6 +1347,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1286,6 +1365,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1305,6 +1385,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1323,6 +1404,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1343,6 +1425,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1362,6 +1445,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1383,6 +1467,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1403,6 +1488,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1427,6 +1513,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1439,6 +1526,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1450,9 +1538,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code error} level is enabled.
-     */
+    /** Returns {@code true} if the {@code error} level is enabled. */
     @Override
     public boolean isErrorEnabled() {
         return delegate.isErrorEnabled(MARKER);
@@ -1460,6 +1546,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1469,6 +1556,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1479,6 +1567,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1488,6 +1577,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1498,6 +1588,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1507,6 +1598,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1517,6 +1609,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1526,6 +1619,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1537,6 +1631,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1546,6 +1641,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1562,6 +1658,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1572,6 +1669,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1589,6 +1687,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1605,6 +1704,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1623,6 +1723,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1640,6 +1741,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1659,6 +1761,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1677,6 +1780,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1697,6 +1801,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1716,6 +1821,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1737,6 +1843,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1757,6 +1864,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1781,6 +1889,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1793,6 +1902,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace

--- a/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
+++ b/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
@@ -34,9 +34,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
         this.delegate = Objects.requireNonNull(delegate, "Slf4j Logger is required");
     }
 
-    /**
-     * Returns {@code true} if the {@code trace} level is enabled.
-     */
+    /** Returns {@code true} if the {@code trace} level is enabled. */
     @Override
     public boolean isTraceEnabled() {
         return delegate.isTraceEnabled(MARKER);
@@ -44,6 +42,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -53,6 +52,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -63,6 +63,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -72,6 +73,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -82,6 +84,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -91,6 +94,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -103,6 +107,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -114,6 +119,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -127,6 +133,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -138,6 +145,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -156,6 +164,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -168,6 +177,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -187,6 +197,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -205,6 +216,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -225,6 +237,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -244,6 +257,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -265,6 +279,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -285,6 +300,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -307,6 +323,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -328,6 +345,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -351,6 +369,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -373,6 +392,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -397,6 +417,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -409,6 +430,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -420,9 +442,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code debug} level is enabled.
-     */
+    /** Returns {@code true} if the {@code debug} level is enabled. */
     @Override
     public boolean isDebugEnabled() {
         return delegate.isDebugEnabled(MARKER);
@@ -430,6 +450,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -439,6 +460,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -449,6 +471,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -458,6 +481,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -468,6 +492,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -477,6 +502,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -489,6 +515,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -500,6 +527,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -513,6 +541,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -524,6 +553,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -542,6 +572,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -554,6 +585,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -573,6 +605,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -591,6 +624,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -611,6 +645,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -630,6 +665,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -651,6 +687,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -671,6 +708,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -693,6 +731,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -714,6 +753,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -737,6 +777,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -759,6 +800,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -783,6 +825,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -795,6 +838,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -806,9 +850,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code info} level is enabled.
-     */
+    /** Returns {@code true} if the {@code info} level is enabled. */
     @Override
     public boolean isInfoEnabled() {
         return delegate.isInfoEnabled(MARKER);
@@ -816,6 +858,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -825,6 +868,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -835,6 +879,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -844,6 +889,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -854,6 +900,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -863,6 +910,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -875,6 +923,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -886,6 +935,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -899,6 +949,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -910,6 +961,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -928,6 +980,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -940,6 +993,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -959,6 +1013,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -977,6 +1032,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -997,6 +1053,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1016,6 +1073,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1037,6 +1095,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1057,6 +1116,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1079,6 +1139,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1100,6 +1161,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1123,6 +1185,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1145,6 +1208,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1169,6 +1233,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1181,6 +1246,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1192,9 +1258,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code warn} level is enabled.
-     */
+    /** Returns {@code true} if the {@code warn} level is enabled. */
     @Override
     public boolean isWarnEnabled() {
         return delegate.isWarnEnabled(MARKER);
@@ -1202,6 +1266,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1211,6 +1276,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1221,6 +1287,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1230,6 +1297,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1240,6 +1308,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1249,6 +1318,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1261,6 +1331,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1272,6 +1343,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1285,6 +1357,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1296,6 +1369,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1314,6 +1388,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1326,6 +1401,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1345,6 +1421,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1363,6 +1440,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1383,6 +1461,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1402,6 +1481,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1423,6 +1503,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1443,6 +1524,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1465,6 +1547,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1486,6 +1569,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1509,6 +1593,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1531,6 +1616,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1555,6 +1641,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1567,6 +1654,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1578,9 +1666,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
         }
     }
 
-    /**
-     * Returns {@code true} if the {@code error} level is enabled.
-     */
+    /** Returns {@code true} if the {@code error} level is enabled. */
     @Override
     public boolean isErrorEnabled() {
         return delegate.isErrorEnabled(MARKER);
@@ -1588,6 +1674,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1597,6 +1684,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1607,6 +1695,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1616,6 +1705,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1626,6 +1716,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1635,6 +1726,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1647,6 +1739,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1658,6 +1751,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1671,6 +1765,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1682,6 +1777,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1700,6 +1796,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1712,6 +1809,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1731,6 +1829,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1749,6 +1848,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1769,6 +1869,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1788,6 +1889,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1809,6 +1911,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1829,6 +1932,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1851,6 +1955,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1872,6 +1977,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1895,6 +2001,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
@@ -1917,6 +2024,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1941,6 +2049,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1953,6 +2062,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace

--- a/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
+++ b/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
@@ -20,25 +20,25 @@ import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
 /**
- * Logger bridge which must be implemented by frameworks which implement the safe-logging facade API.
- * Methods should only be called by the safe-logger implementation, the bridge is not meant to be used directly.
+ * Logger bridge which must be implemented by frameworks which implement the safe-logging facade API. Methods should
+ * only be called by the safe-logger implementation, the bridge is not meant to be used directly.
  */
 @Generated("com.palantir.logsafe.logger.generator.LoggerGenerator")
 @SuppressWarnings("TooManyArguments")
 public interface SafeLoggerBridge {
-    /**
-     * Returns {@code true} if the {@code trace} level is enabled.
-     */
+    /** Returns {@code true} if the {@code trace} level is enabled. */
     boolean isTraceEnabled();
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -46,12 +46,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -59,12 +61,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -72,12 +76,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -86,12 +92,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -105,12 +113,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -125,6 +135,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
@@ -138,6 +149,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -153,6 +165,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
@@ -167,6 +180,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -183,6 +197,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
@@ -198,6 +213,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -215,6 +231,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
@@ -231,6 +248,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -249,6 +267,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
@@ -266,6 +285,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -285,6 +305,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -292,25 +313,26 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
     void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
-    /**
-     * Returns {@code true} if the {@code debug} level is enabled.
-     */
+    /** Returns {@code true} if the {@code debug} level is enabled. */
     boolean isDebugEnabled();
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -318,12 +340,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -331,12 +355,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -344,12 +370,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -358,12 +386,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -377,12 +407,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -397,6 +429,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
@@ -410,6 +443,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -425,6 +459,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
@@ -439,6 +474,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -455,6 +491,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
@@ -470,6 +507,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -487,6 +525,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
@@ -503,6 +542,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -521,6 +561,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
@@ -538,6 +579,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -557,6 +599,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -564,25 +607,26 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
     void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
-    /**
-     * Returns {@code true} if the {@code info} level is enabled.
-     */
+    /** Returns {@code true} if the {@code info} level is enabled. */
     boolean isInfoEnabled();
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -590,12 +634,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -603,12 +649,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -616,12 +664,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -630,12 +680,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -649,12 +701,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -669,6 +723,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
@@ -682,6 +737,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -697,6 +753,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
@@ -711,6 +768,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -727,6 +785,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
@@ -742,6 +801,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -759,6 +819,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
@@ -775,6 +836,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -793,6 +855,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
@@ -810,6 +873,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -829,6 +893,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -836,25 +901,26 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
     void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
-    /**
-     * Returns {@code true} if the {@code warn} level is enabled.
-     */
+    /** Returns {@code true} if the {@code warn} level is enabled. */
     boolean isWarnEnabled();
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -862,12 +928,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -875,12 +943,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -888,12 +958,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -902,12 +974,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -921,12 +995,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -941,6 +1017,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
@@ -954,6 +1031,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -969,6 +1047,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
@@ -983,6 +1062,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -999,6 +1079,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
@@ -1014,6 +1095,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1031,6 +1113,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
@@ -1047,6 +1130,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1065,6 +1149,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
@@ -1082,6 +1167,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1101,6 +1187,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1108,25 +1195,26 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
     void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
-    /**
-     * Returns {@code true} if the {@code error} level is enabled.
-     */
+    /** Returns {@code true} if the {@code error} level is enabled. */
     boolean isErrorEnabled();
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1134,12 +1222,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1147,12 +1237,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1160,12 +1252,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1174,12 +1268,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1193,12 +1289,14 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1213,6 +1311,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
@@ -1226,6 +1325,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1241,6 +1341,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
@@ -1255,6 +1356,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1271,6 +1373,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
@@ -1286,6 +1389,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1303,6 +1407,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
@@ -1319,6 +1424,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1337,6 +1443,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
@@ -1354,6 +1461,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1373,6 +1481,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1380,6 +1489,7 @@ public interface SafeLoggerBridge {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace

--- a/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
+++ b/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
@@ -21,30 +21,25 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
-/**
- * Safe-logging logger API used to produce log events with safe-classified {@link Arg} values.
- */
+/** Safe-logging logger API used to produce log events with safe-classified {@link Arg} values. */
 @Generated("com.palantir.logsafe.logger.generator.LoggerGenerator")
 @SuppressWarnings("TooManyArguments")
 public final class SafeLogger {
     private final SafeLoggerBridge delegate;
 
-    /**
-     * Internal package-private constructor for {@link SafeLoggerFactory}.
-     */
+    /** Internal package-private constructor for {@link SafeLoggerFactory}. */
     SafeLogger(SafeLoggerBridge delegate) {
         this.delegate = Objects.requireNonNull(delegate, "SafeLoggerBridge is required");
     }
 
-    /**
-     * Returns {@code true} if the {@code trace} level is enabled.
-     */
+    /** Returns {@code true} if the {@code trace} level is enabled. */
     public boolean isTraceEnabled() {
         return delegate.isTraceEnabled();
     }
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(@CompileTimeConstant String message) {
@@ -53,6 +48,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -62,6 +58,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(@CompileTimeConstant String message, Arg<?> arg0) {
@@ -70,6 +67,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -79,6 +77,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
@@ -87,6 +86,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -96,6 +96,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
@@ -104,6 +105,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -114,6 +116,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -122,6 +125,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -137,6 +141,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -146,6 +151,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -162,6 +168,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -177,6 +184,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -194,6 +202,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -210,6 +219,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -228,6 +238,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -245,6 +256,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -264,6 +276,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -282,6 +295,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -302,6 +316,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
@@ -321,6 +336,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -342,6 +358,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -351,6 +368,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code trace} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -359,15 +377,14 @@ public final class SafeLogger {
         delegate.trace(message, args, throwable);
     }
 
-    /**
-     * Returns {@code true} if the {@code debug} level is enabled.
-     */
+    /** Returns {@code true} if the {@code debug} level is enabled. */
     public boolean isDebugEnabled() {
         return delegate.isDebugEnabled();
     }
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(@CompileTimeConstant String message) {
@@ -376,6 +393,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -385,6 +403,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(@CompileTimeConstant String message, Arg<?> arg0) {
@@ -393,6 +412,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -402,6 +422,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
@@ -410,6 +431,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -419,6 +441,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
@@ -427,6 +450,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -437,6 +461,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -445,6 +470,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -460,6 +486,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -469,6 +496,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -485,6 +513,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -500,6 +529,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -517,6 +547,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -533,6 +564,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -551,6 +583,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -568,6 +601,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -587,6 +621,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -605,6 +640,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -625,6 +661,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
@@ -644,6 +681,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -665,6 +703,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -674,6 +713,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code debug} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -682,15 +722,14 @@ public final class SafeLogger {
         delegate.debug(message, args, throwable);
     }
 
-    /**
-     * Returns {@code true} if the {@code info} level is enabled.
-     */
+    /** Returns {@code true} if the {@code info} level is enabled. */
     public boolean isInfoEnabled() {
         return delegate.isInfoEnabled();
     }
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(@CompileTimeConstant String message) {
@@ -699,6 +738,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -708,6 +748,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(@CompileTimeConstant String message, Arg<?> arg0) {
@@ -716,6 +757,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -725,6 +767,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
@@ -733,6 +776,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -742,6 +786,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
@@ -750,6 +795,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -760,6 +806,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -768,6 +815,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -783,6 +831,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -792,6 +841,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -808,6 +858,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -823,6 +874,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -840,6 +892,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -856,6 +909,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -874,6 +928,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -891,6 +946,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -910,6 +966,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -928,6 +985,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -948,6 +1006,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
@@ -967,6 +1026,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -988,6 +1048,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -997,6 +1058,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code info} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1005,15 +1067,14 @@ public final class SafeLogger {
         delegate.info(message, args, throwable);
     }
 
-    /**
-     * Returns {@code true} if the {@code warn} level is enabled.
-     */
+    /** Returns {@code true} if the {@code warn} level is enabled. */
     public boolean isWarnEnabled() {
         return delegate.isWarnEnabled();
     }
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(@CompileTimeConstant String message) {
@@ -1022,6 +1083,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1031,6 +1093,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(@CompileTimeConstant String message, Arg<?> arg0) {
@@ -1039,6 +1102,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1048,6 +1112,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
@@ -1056,6 +1121,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1065,6 +1131,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
@@ -1073,6 +1140,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1083,6 +1151,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -1091,6 +1160,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1106,6 +1176,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1115,6 +1186,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1131,6 +1203,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1146,6 +1219,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1163,6 +1237,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1179,6 +1254,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1197,6 +1273,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1214,6 +1291,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1233,6 +1311,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1251,6 +1330,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1271,6 +1351,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
@@ -1290,6 +1371,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1311,6 +1393,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1320,6 +1403,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code warn} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
@@ -1328,15 +1412,14 @@ public final class SafeLogger {
         delegate.warn(message, args, throwable);
     }
 
-    /**
-     * Returns {@code true} if the {@code error} level is enabled.
-     */
+    /** Returns {@code true} if the {@code error} level is enabled. */
     public boolean isErrorEnabled() {
         return delegate.isErrorEnabled();
     }
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(@CompileTimeConstant String message) {
@@ -1345,6 +1428,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1354,6 +1438,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(@CompileTimeConstant String message, Arg<?> arg0) {
@@ -1362,6 +1447,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1371,6 +1457,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
@@ -1379,6 +1466,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1388,6 +1476,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
@@ -1396,6 +1485,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1406,6 +1496,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
@@ -1414,6 +1505,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1429,6 +1521,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1438,6 +1531,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1454,6 +1548,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1469,6 +1564,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1486,6 +1582,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1502,6 +1599,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1520,6 +1618,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1537,6 +1636,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1556,6 +1656,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1574,6 +1675,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1594,6 +1696,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
@@ -1613,6 +1716,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
@@ -1634,6 +1738,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
@@ -1643,6 +1748,7 @@ public final class SafeLogger {
 
     /**
      * Logs the provided parameters at {@code error} level.
+     *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace


### PR DESCRIPTION
These were changing during CircleCI builds, causing the version to get `.dirty` and publishing to fail.