### PR TITLE
Annotate (Unsafe|Safe)Arg's name with @Safe

### DIFF
--- a/changelog/@unreleased/pr-958.v2.yml
+++ b/changelog/@unreleased/pr-958.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotate (Unsafe|Safe)Arg's name with @Safe
+  links:
+  - https://github.com/palantir/safe-logging/pull/958

--- a/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/SafeArg.java
@@ -26,7 +26,7 @@ public final class SafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> SafeArg<T> of(String name, @Safe @Nullable T value) {
+    public static <T> SafeArg<T> of(@Safe String name, @Safe @Nullable T value) {
         return new SafeArg<>(name, value);
     }
 

--- a/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
+++ b/safe-logging/src/main/java/com/palantir/logsafe/UnsafeArg.java
@@ -26,7 +26,7 @@ public final class UnsafeArg<T> extends Arg<T> {
         super(name, value);
     }
 
-    public static <T> UnsafeArg<T> of(String name, @Nullable @Unsafe T value) {
+    public static <T> UnsafeArg<T> of(@Safe String name, @Nullable @Unsafe T value) {
         return new UnsafeArg<>(name, value);
     }
 


### PR DESCRIPTION
## Before this PR

One can erronously pass unsafe strings as the first arg of `(Unsafe|Safe)Arg`'s `of` method.

## After this PR

==COMMIT_MSG==
Annotate (Unsafe|Safe)Arg's name with @Safe
==COMMIT_MSG==