### PR TITLE
accept list arg as parameter in preconditions

### DIFF
--- a/changelog/@unreleased/pr-1083.v2.yml
+++ b/changelog/@unreleased/pr-1083.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Preconditions' methods now accept List<Arg<?>> as a parameter.
+  links:
+  - https://github.com/palantir/safe-logging/pull/1083

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -116,7 +116,7 @@ public final class Preconditions {
     public static void checkArgument(
             boolean expression, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (!expression) {
-            throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
+            throw new SafeIllegalArgumentException(message, args);
         }
     }
 
@@ -228,7 +228,7 @@ public final class Preconditions {
     public static <T> T checkArgumentNotNull(
             @Nullable T reference, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (reference == null) {
-            throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
+            throw new SafeIllegalArgumentException(message, args);
         }
         return reference;
     }
@@ -328,7 +328,7 @@ public final class Preconditions {
     public static void checkState(
             boolean expression, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (!expression) {
-            throw new SafeIllegalStateException(message, args.toArray(new Arg<?>[0]));
+            throw new SafeIllegalStateException(message, args);
         }
     }
 
@@ -441,7 +441,7 @@ public final class Preconditions {
     public static <T> T checkNotNull(
             @Nullable T reference, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (reference == null) {
-            throw new SafeNullPointerException(message, args.toArray(new Arg<?>[0]));
+            throw new SafeNullPointerException(message, args);
         }
         return reference;
     }

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -34,6 +34,7 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.Contract;
@@ -103,6 +104,18 @@ public final class Preconditions {
             boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, arg1, arg2, arg3);
+        }
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
+     */
+    @Contract("false, _, _ -> fail")
+    public static void checkArgument(boolean expression, @CompileTimeConstant String message, List<Arg<?>> args) {
+        if (!expression) {
+            throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
         }
     }
 
@@ -206,6 +219,22 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
+     * <p>See {@link #checkArgumentNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
+    public static <T> T checkArgumentNotNull(
+            @Nullable T reference, @CompileTimeConstant String message, List<Arg<?>> args) {
+        if (reference == null) {
+            throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
      * @param reference an String reference
      * @param message   the loggable exception message
      * @param args      the arguments to include in the {@link SafeIllegalArgumentException}
@@ -286,6 +315,18 @@ public final class Preconditions {
             boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg1, arg2, arg3);
+        }
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * <p>See {@link #checkState(boolean, String, Arg...)} for details.
+     */
+    @Contract("false, _, _ -> fail")
+    public static void checkState(boolean expression, @CompileTimeConstant String message, List<Arg<?>> args) {
+        if (!expression) {
+            throw new SafeIllegalStateException(message, args.toArray(new Arg<?>[0]));
         }
     }
 
@@ -383,6 +424,21 @@ public final class Preconditions {
             @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg1, arg2, arg3);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkNotNull(Object, String, Arg...)} for details.
+     */
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, List<Arg<?>> args) {
+        if (reference == null) {
+            throw new SafeNullPointerException(message, args.toArray(new Arg<?>[0]));
         }
         return reference;
     }

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -113,7 +113,8 @@ public final class Preconditions {
      * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
      */
     @Contract("false, _, _ -> fail")
-    public static void checkArgument(boolean expression, @CompileTimeConstant String message, List<Arg<?>> args) {
+    public static void checkArgument(
+            boolean expression, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
         }
@@ -225,7 +226,7 @@ public final class Preconditions {
     @CanIgnoreReturnValue
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, List<Arg<?>> args) {
+            @Nullable T reference, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message, args.toArray(new Arg<?>[0]));
         }
@@ -324,7 +325,8 @@ public final class Preconditions {
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
     @Contract("false, _, _ -> fail")
-    public static void checkState(boolean expression, @CompileTimeConstant String message, List<Arg<?>> args) {
+    public static void checkState(
+            boolean expression, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (!expression) {
             throw new SafeIllegalStateException(message, args.toArray(new Arg<?>[0]));
         }
@@ -436,7 +438,8 @@ public final class Preconditions {
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, List<Arg<?>> args) {
+    public static <T> T checkNotNull(
+            @Nullable T reference, @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (reference == null) {
             throw new SafeNullPointerException(message, args.toArray(new Arg<?>[0]));
         }

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -19,13 +19,14 @@ package com.palantir.logsafe.exceptions;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import java.util.Arrays;
+import java.util.List;
 
 /** {@link SafeExceptions} provides utility functionality for SafeLoggable exception implementations. */
 public final class SafeExceptions {
     private SafeExceptions() {}
 
-    public static String renderMessage(@CompileTimeConstant String safeMessage, Arg<?>... args) {
-        if (args == null || args.length == 0) {
+    public static String renderMessage(@CompileTimeConstant String safeMessage, List<? extends Arg<?>> args) {
+        if (args == null || args.isEmpty()) {
             return safeMessage;
         }
 
@@ -47,6 +48,14 @@ public final class SafeExceptions {
         builder.append('}');
 
         return builder.toString();
+    }
+
+    public static String renderMessage(@CompileTimeConstant String safeMessage, Arg<?>... args) {
+        if (args == null || args.length == 0) {
+            return safeMessage;
+        }
+
+        return renderMessage(safeMessage, Arrays.asList(args));
     }
 
     private static void appendValue(StringBuilder builder, Arg<?> arg) {

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
@@ -34,17 +34,26 @@ public final class SafeIllegalArgumentException extends IllegalArgumentException
         this.arguments = Collections.emptyList();
     }
 
-    public SafeIllegalArgumentException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIllegalArgumentException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIllegalArgumentException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, List<? extends Arg<?>> arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIllegalArgumentException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     public SafeIllegalArgumentException(
             @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(message, cause, Arrays.asList(arguments));
     }
 
     public SafeIllegalArgumentException(@Nullable Throwable cause) {

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
@@ -34,17 +34,26 @@ public final class SafeIllegalStateException extends IllegalStateException imple
         this.arguments = Collections.emptyList();
     }
 
-    public SafeIllegalStateException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIllegalStateException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIllegalStateException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, List<? extends Arg<?>> arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIllegalStateException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     public SafeIllegalStateException(
             @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(message, cause, Arrays.asList(arguments));
     }
 
     public SafeIllegalStateException(@Nullable Throwable cause) {

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
@@ -29,16 +29,25 @@ public final class SafeIoException extends IOException implements SafeLoggable {
     private final String logMessage;
     private final List<Arg<?>> arguments;
 
-    public SafeIoException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIoException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIoException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, List<? extends Arg<?>> arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeIoException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     public SafeIoException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(message, cause, Arrays.asList(arguments));
     }
 
     @Override

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeNullPointerException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeNullPointerException.java
@@ -33,10 +33,14 @@ public final class SafeNullPointerException extends NullPointerException impleme
         this.arguments = Collections.emptyList();
     }
 
-    public SafeNullPointerException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeNullPointerException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeNullPointerException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     @Override

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
@@ -34,16 +34,25 @@ public final class SafeRuntimeException extends RuntimeException implements Safe
         this.arguments = Collections.emptyList();
     }
 
-    public SafeRuntimeException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeRuntimeException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeRuntimeException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, List<? extends Arg<?>> arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeRuntimeException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     public SafeRuntimeException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(message, cause, Arrays.asList(arguments));
     }
 
     public SafeRuntimeException(@Nullable Throwable cause) {

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
@@ -31,10 +31,15 @@ public final class SafeUncheckedIoException extends UncheckedIOException impleme
     private final List<Arg<?>> arguments;
 
     public SafeUncheckedIoException(
-            @CompileTimeConstant String message, @Nullable IOException cause, Arg<?>... arguments) {
+            @CompileTimeConstant String message, @Nullable IOException cause, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeUncheckedIoException(
+            @CompileTimeConstant String message, @Nullable IOException cause, Arg<?>... arguments) {
+        this(message, cause, Arrays.asList(arguments));
     }
 
     public SafeUncheckedIoException(@Nullable IOException cause) {

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
@@ -34,17 +34,26 @@ public final class SafeUnsupportedOperationException extends UnsupportedOperatio
         this.arguments = Collections.emptyList();
     }
 
-    public SafeUnsupportedOperationException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeUnsupportedOperationException(@CompileTimeConstant String message, List<? extends Arg<?>> arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeUnsupportedOperationException(
+            @CompileTimeConstant String message, @Nullable Throwable cause, List<? extends Arg<?>> arguments) {
+        super(SafeExceptions.renderMessage(message, arguments), cause);
+        this.logMessage = message;
+        this.arguments = Collections.unmodifiableList(arguments);
+    }
+
+    public SafeUnsupportedOperationException(@CompileTimeConstant String message, Arg<?>... arguments) {
+        this(message, Arrays.asList(arguments));
     }
 
     public SafeUnsupportedOperationException(
             @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(message, cause, Arrays.asList(arguments));
     }
 
     public SafeUnsupportedOperationException(@Nullable Throwable cause) {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We cannot pass List<Arg<?>> to Preconditions methods unlike SafeLogger methods which create duality between those two classes.

## After this PR
We can also pass List<Arg<?>> to Preconditions methods like SafeLogger methods. 

SafeLogger methods only support List<Arg<?>>
Preconditions methods only support Arg<?>...

In our service, we have an utility function that returns List<Arg<?>>. It makes sense for it to work with both Preconditions and SafeLogger without requiring converting List to Arg<?>[] each time.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Preconditions' methods now accept List<Arg<?>> as a parameter.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
- Should we also add Arg<?>... definition to the SafeLogger? I'd except at least one common parameter type between Exceptions, SafeLogger, and Preconditions
- Should we also duplicate the work inside Exceptions?

