### PR TITLE
Expose InstaceOfAssertFactory for exception asserts

### DIFF
--- a/changelog/@unreleased/pr-1157.v2.yml
+++ b/changelog/@unreleased/pr-1157.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: '`LoggableExceptionAssert` exposes a static `instanceOfAssertFactory`
+    method which provides an `InstanceOfAssertFactory` that can be used to downcast
+    these types in assertions using `asInstanceOf`.'
+  links:
+  - https://github.com/palantir/safe-logging/pull/1157

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/Assertions.java
@@ -21,7 +21,6 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import com.palantir.logsafe.exceptions.SafeIoException;
 import com.palantir.logsafe.exceptions.SafeNullPointerException;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
@@ -55,13 +54,6 @@ public class Assertions extends org.assertj.core.api.Assertions {
     @CanIgnoreReturnValue
     public static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> assertThatLoggableExceptionThrownBy(
             ThrowingCallable shouldRaiseThrowable) {
-        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(loggableExceptionAssertFactory());
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T extends Throwable & SafeLoggable>
-            InstanceOfAssertFactory<SafeLoggable, LoggableExceptionAssert<T>> loggableExceptionAssertFactory() {
-        return new InstanceOfAssertFactory<>(
-                SafeLoggable.class, safeLoggable -> LoggableExceptionAssert.create((T) safeLoggable));
+        return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(LoggableExceptionAssert.instanceOfAssertFactory());
     }
 }

--- a/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
+++ b/preconditions-assertj/src/main/java/com/palantir/logsafe/testing/LoggableExceptionAssert.java
@@ -21,6 +21,7 @@ import com.palantir.logsafe.SafeLoggable;
 import java.util.Collections;
 import java.util.List;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.util.Objects;
 
@@ -30,6 +31,13 @@ public final class LoggableExceptionAssert<T extends Throwable & SafeLoggable>
 
     static <T extends Throwable & SafeLoggable> LoggableExceptionAssert<T> create(T actual) {
         return new LoggableExceptionAssert<>(actual).withRepresentation(LoggableArgRepresentation.INSTANCE);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Throwable & SafeLoggable>
+            InstanceOfAssertFactory<SafeLoggable, LoggableExceptionAssert<T>> instanceOfAssertFactory() {
+        return new InstanceOfAssertFactory<>(
+                SafeLoggable.class, safeLoggable -> LoggableExceptionAssert.create((T) safeLoggable));
     }
 
     private LoggableExceptionAssert(T actual) {


### PR DESCRIPTION
Same as https://github.com/palantir/conjure-java-runtime-api/pull/1074, but for `LoggableExceptionAssert`.