### PR TITLE
Implement SafeExceptionData util for easy `SafeLoggable` implementation

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptionData.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptionData.java
@@ -1,0 +1,85 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.logsafe.exceptions;
+
+import com.google.errorprone.annotations.CompileTimeConstant;
+import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
+import com.palantir.logsafe.Unsafe;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper to ease the process of defining custom {@link com.palantir.logsafe.SafeLoggable} {@link Throwable throwables}.
+ */
+@Unsafe
+public final class SafeExceptionData {
+
+    private static final SafeExceptionData EMPTY = new SafeExceptionData("", "", List.of());
+
+    @Safe
+    @CompileTimeConstant
+    private final String logMessage;
+
+    @Unsafe
+    private final String unsafeMessage;
+
+    private final List<Arg<?>> arguments;
+
+    /** Returns an empty {@link SafeExceptionData} instance. */
+    public static SafeExceptionData of() {
+        return EMPTY;
+    }
+
+    public static SafeExceptionData of(@Safe @CompileTimeConstant String logMessage, Arg<?>... arguments) {
+        return new SafeExceptionData(
+                logMessage,
+                SafeExceptions.renderMessage(logMessage, arguments),
+                Collections.unmodifiableList(Arrays.asList(arguments)));
+    }
+
+    private SafeExceptionData(
+            @Safe @CompileTimeConstant String logMessage, @Unsafe String unsafeMessage, List<Arg<?>> arguments) {
+        this.logMessage = logMessage;
+        this.unsafeMessage = unsafeMessage;
+        this.arguments = arguments;
+    }
+
+    @Safe
+    public String logMessage() {
+        return logMessage;
+    }
+
+    @Unsafe
+    public String unsafeMessage() {
+        return unsafeMessage;
+    }
+
+    public List<Arg<?>> args() {
+        return arguments;
+    }
+
+    @Unsafe
+    @Override
+    public String toString() {
+        return "SafeExceptionData{logMessage='"
+                + logMessage + '\'' + ", unsafeMessage='"
+                + unsafeMessage + '\'' + ", arguments="
+                + arguments + '}';
+    }
+}

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
@@ -19,47 +19,41 @@ package com.palantir.logsafe.exceptions;
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeLoggable;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 public final class SafeIllegalArgumentException extends IllegalArgumentException implements SafeLoggable {
-    private final String logMessage;
-    private final List<Arg<?>> arguments;
+    private final SafeExceptionData data;
 
     public SafeIllegalArgumentException() {
-        super("");
-        this.logMessage = "";
-        this.arguments = Collections.emptyList();
+        this(SafeExceptionData.of(), null);
     }
 
     public SafeIllegalArgumentException(@CompileTimeConstant String message, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments));
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(SafeExceptionData.of(message, arguments), null);
     }
 
     public SafeIllegalArgumentException(
             @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
-        super(SafeExceptions.renderMessage(message, arguments), cause);
-        this.logMessage = message;
-        this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
+        this(SafeExceptionData.of(message, arguments), cause);
     }
 
     public SafeIllegalArgumentException(@Nullable Throwable cause) {
-        super("", cause);
-        this.logMessage = "";
-        this.arguments = Collections.emptyList();
+        this(SafeExceptionData.of(), cause);
+    }
+
+    private SafeIllegalArgumentException(SafeExceptionData data, @Nullable Throwable cause) {
+        super(data.unsafeMessage(), cause);
+        this.data = data;
     }
 
     @Override
     public String getLogMessage() {
-        return logMessage;
+        return data.logMessage();
     }
 
     @Override
     public List<Arg<?>> getArgs() {
-        return arguments;
+        return data.args();
     }
 }


### PR DESCRIPTION
This is a proof of concept to illustrate an idea, I've only taken advantage of the new type in `SafeIllegalArgumentException.java`. Is this a good idea? I'm not entirely sure yet. I don't think the existing utility functionality is terribly difficult to use, but others have voiced frustration with it.

## Before this PR
Our `SafeExceptions.renderMessage` util required tracking a couple additional fields in each `SafeLoggable` exception. This might be a bit easier to deal with.

## After this PR
==COMMIT_MSG==
Implement SafeExceptionData util for easy `SafeLoggable` implementation
==COMMIT_MSG==

## Possible downsides?
More public API surface area

