### PR TITLE
Annotate All `@CompileTimeConstant`'s with `@Safe` Annotation

### DIFF
--- a/changelog/@unreleased/pr-1186.v2.yml
+++ b/changelog/@unreleased/pr-1186.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Annotate All `@CompileTimeConstant`'s with `@Safe` Annotation
+  links:
+  - https://github.com/palantir/safe-logging/pull/1186

--- a/logger-generator/src/main/java/com/palantir/logsafe/logger/generator/LoggerGenerator.java
+++ b/logger-generator/src/main/java/com/palantir/logsafe/logger/generator/LoggerGenerator.java
@@ -141,6 +141,7 @@ public final class LoggerGenerator {
                     .build());
 
             ParameterSpec messageParameter = ParameterSpec.builder(String.class, "message")
+                    .addAnnotation(Safe.class)
                     .addAnnotation(CompileTimeConstant.class)
                     .addJavadoc("Message string to log, supports slf4j-style curly-brace interpolation\n")
                     .build();

--- a/logger-log4j/src/main/java/com/palantir/logsafe/logger/log4j/Log4jSafeLoggerBridge.java
+++ b/logger-log4j/src/main/java/com/palantir/logsafe/logger/log4j/Log4jSafeLoggerBridge.java
@@ -15,6 +15,7 @@ package com.palantir.logsafe.logger.log4j;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.logger.spi.SafeLoggerBridge;
 import java.util.List;
 import java.util.Objects;
@@ -46,7 +47,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message) {
+    public void trace(@Safe @CompileTimeConstant String message) {
         delegate.trace(MARKER, message);
     }
 
@@ -57,7 +58,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, throwable);
     }
 
@@ -67,7 +68,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.trace(MARKER, message, arg0);
     }
 
@@ -78,7 +79,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, arg0, throwable);
     }
 
@@ -88,7 +89,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.trace(MARKER, message, arg0, arg1);
     }
 
@@ -99,7 +100,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, arg0, arg1, throwable);
     }
 
@@ -109,7 +111,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.trace(MARKER, message, arg0, arg1, arg2);
     }
 
@@ -121,7 +123,11 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, arg0, arg1, arg2, throwable);
     }
 
@@ -131,7 +137,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.trace(MARKER, message, arg0, arg1, arg2, arg3);
     }
 
@@ -143,7 +149,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -159,7 +165,12 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -171,7 +182,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -188,7 +199,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -206,7 +217,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -224,7 +235,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -243,7 +254,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -262,7 +273,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -282,7 +293,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -302,7 +313,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -323,7 +334,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -344,7 +355,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -366,7 +377,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -390,7 +401,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void trace(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, args.toArray(new Object[0]));
         }
@@ -404,7 +415,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, merge(args, throwable));
         }
@@ -422,7 +434,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message) {
+    public void debug(@Safe @CompileTimeConstant String message) {
         delegate.debug(MARKER, message);
     }
 
@@ -433,7 +445,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, throwable);
     }
 
@@ -443,7 +455,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.debug(MARKER, message, arg0);
     }
 
@@ -454,7 +466,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, arg0, throwable);
     }
 
@@ -464,7 +476,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.debug(MARKER, message, arg0, arg1);
     }
 
@@ -475,7 +487,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, arg0, arg1, throwable);
     }
 
@@ -485,7 +498,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.debug(MARKER, message, arg0, arg1, arg2);
     }
 
@@ -497,7 +510,11 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, arg0, arg1, arg2, throwable);
     }
 
@@ -507,7 +524,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.debug(MARKER, message, arg0, arg1, arg2, arg3);
     }
 
@@ -519,7 +536,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -535,7 +552,12 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -547,7 +569,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -564,7 +586,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -582,7 +604,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -600,7 +622,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -619,7 +641,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -638,7 +660,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -658,7 +680,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -678,7 +700,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -699,7 +721,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -720,7 +742,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -742,7 +764,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -766,7 +788,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void debug(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, args.toArray(new Object[0]));
         }
@@ -780,7 +802,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, merge(args, throwable));
         }
@@ -798,7 +821,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message) {
+    public void info(@Safe @CompileTimeConstant String message) {
         delegate.info(MARKER, message);
     }
 
@@ -809,7 +832,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, throwable);
     }
 
@@ -819,7 +842,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.info(MARKER, message, arg0);
     }
 
@@ -830,7 +853,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, arg0, throwable);
     }
 
@@ -840,7 +863,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.info(MARKER, message, arg0, arg1);
     }
 
@@ -851,7 +874,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, arg0, arg1, throwable);
     }
 
@@ -861,7 +885,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.info(MARKER, message, arg0, arg1, arg2);
     }
 
@@ -873,7 +897,11 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.info(MARKER, message, arg0, arg1, arg2, throwable);
     }
 
@@ -883,7 +911,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.info(MARKER, message, arg0, arg1, arg2, arg3);
     }
 
@@ -895,7 +923,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -911,7 +939,12 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -923,7 +956,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -940,7 +973,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -958,7 +991,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -976,7 +1009,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -995,7 +1028,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1014,7 +1047,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1034,7 +1067,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1054,7 +1087,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1075,7 +1108,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1096,7 +1129,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1118,7 +1151,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1142,7 +1175,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void info(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, args.toArray(new Object[0]));
         }
@@ -1156,7 +1189,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, merge(args, throwable));
         }
@@ -1174,7 +1208,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message) {
+    public void warn(@Safe @CompileTimeConstant String message) {
         delegate.warn(MARKER, message);
     }
 
@@ -1185,7 +1219,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, throwable);
     }
 
@@ -1195,7 +1229,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.warn(MARKER, message, arg0);
     }
 
@@ -1206,7 +1240,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, arg0, throwable);
     }
 
@@ -1216,7 +1250,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.warn(MARKER, message, arg0, arg1);
     }
 
@@ -1227,7 +1261,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, arg0, arg1, throwable);
     }
 
@@ -1237,7 +1272,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.warn(MARKER, message, arg0, arg1, arg2);
     }
 
@@ -1249,7 +1284,11 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, arg0, arg1, arg2, throwable);
     }
 
@@ -1259,7 +1298,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.warn(MARKER, message, arg0, arg1, arg2, arg3);
     }
 
@@ -1271,7 +1310,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1287,7 +1326,12 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -1299,7 +1343,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1316,7 +1360,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1334,7 +1378,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1352,7 +1396,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1371,7 +1415,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1390,7 +1434,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1410,7 +1454,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1430,7 +1474,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1451,7 +1495,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1472,7 +1516,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1494,7 +1538,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1518,7 +1562,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void warn(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, args.toArray(new Object[0]));
         }
@@ -1532,7 +1576,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, merge(args, throwable));
         }
@@ -1550,7 +1595,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message) {
+    public void error(@Safe @CompileTimeConstant String message) {
         delegate.error(MARKER, message);
     }
 
@@ -1561,7 +1606,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, throwable);
     }
 
@@ -1571,7 +1616,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.error(MARKER, message, arg0);
     }
 
@@ -1582,7 +1627,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, arg0, throwable);
     }
 
@@ -1592,7 +1637,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.error(MARKER, message, arg0, arg1);
     }
 
@@ -1603,7 +1648,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, arg0, arg1, throwable);
     }
 
@@ -1613,7 +1659,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.error(MARKER, message, arg0, arg1, arg2);
     }
 
@@ -1625,7 +1671,11 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.error(MARKER, message, arg0, arg1, arg2, throwable);
     }
 
@@ -1635,7 +1685,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.error(MARKER, message, arg0, arg1, arg2, arg3);
     }
 
@@ -1647,7 +1697,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1663,7 +1713,12 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -1675,7 +1730,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1692,7 +1747,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1710,7 +1765,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1728,7 +1783,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1747,7 +1802,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1766,7 +1821,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1786,7 +1841,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1806,7 +1861,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1827,7 +1882,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1848,7 +1903,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1870,7 +1925,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1894,7 +1949,7 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void error(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, args.toArray(new Object[0]));
         }
@@ -1908,7 +1963,8 @@ final class Log4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, merge(args, throwable));
         }

--- a/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
+++ b/logger-slf4j/src/main/java/com/palantir/logsafe/logger/slf4j/Slf4jSafeLoggerBridge.java
@@ -15,6 +15,7 @@ package com.palantir.logsafe.logger.slf4j;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.logger.spi.SafeLoggerBridge;
 import java.util.List;
 import java.util.Objects;
@@ -46,7 +47,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message) {
+    public void trace(@Safe @CompileTimeConstant String message) {
         delegate.trace(MARKER, message);
     }
 
@@ -57,7 +58,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, throwable);
     }
 
@@ -67,7 +68,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.trace(MARKER, message, arg0);
     }
 
@@ -78,7 +79,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.trace(MARKER, message, arg0, throwable);
     }
 
@@ -88,7 +89,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.trace(MARKER, message, arg0, arg1);
     }
 
@@ -99,7 +100,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, throwable);
         }
@@ -111,7 +113,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2);
         }
@@ -125,7 +127,11 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -137,7 +143,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3);
         }
@@ -151,7 +157,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -169,7 +175,12 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, arg0, arg1, arg2, arg3, arg4);
         }
@@ -183,7 +194,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -202,7 +213,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -222,7 +233,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -242,7 +253,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -263,7 +274,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -284,7 +295,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -306,7 +317,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -328,7 +339,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -351,7 +362,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -374,7 +385,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -398,7 +409,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -422,7 +433,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void trace(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, args.toArray(new Object[0]));
         }
@@ -436,7 +447,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isTraceEnabled()) {
             delegate.trace(MARKER, message, merge(args, throwable));
         }
@@ -454,7 +466,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message) {
+    public void debug(@Safe @CompileTimeConstant String message) {
         delegate.debug(MARKER, message);
     }
 
@@ -465,7 +477,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, throwable);
     }
 
@@ -475,7 +487,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.debug(MARKER, message, arg0);
     }
 
@@ -486,7 +498,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.debug(MARKER, message, arg0, throwable);
     }
 
@@ -496,7 +508,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.debug(MARKER, message, arg0, arg1);
     }
 
@@ -507,7 +519,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, throwable);
         }
@@ -519,7 +532,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2);
         }
@@ -533,7 +546,11 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -545,7 +562,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3);
         }
@@ -559,7 +576,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -577,7 +594,12 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, arg0, arg1, arg2, arg3, arg4);
         }
@@ -591,7 +613,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -610,7 +632,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -630,7 +652,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -650,7 +672,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -671,7 +693,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -692,7 +714,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -714,7 +736,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -736,7 +758,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -759,7 +781,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -782,7 +804,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -806,7 +828,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -830,7 +852,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void debug(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, args.toArray(new Object[0]));
         }
@@ -844,7 +866,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isDebugEnabled()) {
             delegate.debug(MARKER, message, merge(args, throwable));
         }
@@ -862,7 +885,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message) {
+    public void info(@Safe @CompileTimeConstant String message) {
         delegate.info(MARKER, message);
     }
 
@@ -873,7 +896,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, throwable);
     }
 
@@ -883,7 +906,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.info(MARKER, message, arg0);
     }
 
@@ -894,7 +917,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.info(MARKER, message, arg0, throwable);
     }
 
@@ -904,7 +927,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.info(MARKER, message, arg0, arg1);
     }
 
@@ -915,7 +938,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, throwable);
         }
@@ -927,7 +951,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2);
         }
@@ -941,7 +965,11 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -953,7 +981,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3);
         }
@@ -967,7 +995,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -985,7 +1013,12 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, arg0, arg1, arg2, arg3, arg4);
         }
@@ -999,7 +1032,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1018,7 +1051,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1038,7 +1071,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1058,7 +1091,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1079,7 +1112,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1100,7 +1133,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1122,7 +1155,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1144,7 +1177,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1167,7 +1200,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1190,7 +1223,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1214,7 +1247,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1238,7 +1271,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void info(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, args.toArray(new Object[0]));
         }
@@ -1252,7 +1285,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isInfoEnabled()) {
             delegate.info(MARKER, message, merge(args, throwable));
         }
@@ -1270,7 +1304,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message) {
+    public void warn(@Safe @CompileTimeConstant String message) {
         delegate.warn(MARKER, message);
     }
 
@@ -1281,7 +1315,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, throwable);
     }
 
@@ -1291,7 +1325,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.warn(MARKER, message, arg0);
     }
 
@@ -1302,7 +1336,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.warn(MARKER, message, arg0, throwable);
     }
 
@@ -1312,7 +1346,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.warn(MARKER, message, arg0, arg1);
     }
 
@@ -1323,7 +1357,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, throwable);
         }
@@ -1335,7 +1370,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2);
         }
@@ -1349,7 +1384,11 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -1361,7 +1400,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3);
         }
@@ -1375,7 +1414,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1393,7 +1432,12 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, arg0, arg1, arg2, arg3, arg4);
         }
@@ -1407,7 +1451,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1426,7 +1470,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1446,7 +1490,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1466,7 +1510,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1487,7 +1531,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1508,7 +1552,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1530,7 +1574,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1552,7 +1596,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1575,7 +1619,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1598,7 +1642,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1622,7 +1666,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1646,7 +1690,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void warn(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, args.toArray(new Object[0]));
         }
@@ -1660,7 +1704,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isWarnEnabled()) {
             delegate.warn(MARKER, message, merge(args, throwable));
         }
@@ -1678,7 +1723,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message) {
+    public void error(@Safe @CompileTimeConstant String message) {
         delegate.error(MARKER, message);
     }
 
@@ -1689,7 +1734,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, throwable);
     }
 
@@ -1699,7 +1744,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.error(MARKER, message, arg0);
     }
 
@@ -1710,7 +1755,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.error(MARKER, message, arg0, throwable);
     }
 
@@ -1720,7 +1765,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.error(MARKER, message, arg0, arg1);
     }
 
@@ -1731,7 +1776,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, throwable);
         }
@@ -1743,7 +1789,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2);
         }
@@ -1757,7 +1803,11 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, throwable);
         }
@@ -1769,7 +1819,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     @Override
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3);
         }
@@ -1783,7 +1833,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1801,7 +1851,12 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, arg0, arg1, arg2, arg3, arg4);
         }
@@ -1815,7 +1870,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1834,7 +1889,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1854,7 +1909,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1874,7 +1929,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1895,7 +1950,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1916,7 +1971,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1938,7 +1993,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1960,7 +2015,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1983,7 +2038,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -2006,7 +2061,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -2030,7 +2085,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      */
     @Override
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -2054,7 +2109,7 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      */
     @Override
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void error(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, args.toArray(new Object[0]));
         }
@@ -2068,7 +2123,8 @@ final class Slf4jSafeLoggerBridge implements SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     @Override
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         if (isErrorEnabled()) {
             delegate.error(MARKER, message, merge(args, throwable));
         }

--- a/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
+++ b/logger-spi/src/main/java/com/palantir/logsafe/logger/spi/SafeLoggerBridge.java
@@ -15,6 +15,7 @@ package com.palantir.logsafe.logger.spi;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
@@ -34,7 +35,7 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void trace(@CompileTimeConstant String message);
+    void trace(@Safe @CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -42,29 +43,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, @Nullable Throwable throwable);
+    void trace(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0);
-
-    /**
-     * Logs the provided parameters at {@code trace} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     * @param throwable Throwable to log with a stack trace
-     */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
-
-    /**
-     * Logs the provided parameters at {@code trace} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -72,14 +58,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -87,15 +73,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code trace} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -104,7 +89,27 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable);
+
+    /**
+     * Logs the provided parameters at {@code trace} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     */
+    void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+
+    /**
+     * Logs the provided parameters at {@code trace} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     * @param throwable Throwable to log with a stack trace
+     */
+    void trace(
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -116,7 +121,8 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
+    void trace(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -125,7 +131,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -139,7 +145,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -154,7 +160,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -169,7 +175,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -185,7 +191,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -201,7 +207,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -218,7 +224,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -235,7 +241,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -253,7 +259,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -271,7 +277,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -290,7 +296,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -309,7 +315,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args);
+    void trace(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args);
 
     /**
      * Logs the provided parameters at {@code trace} level.
@@ -318,7 +324,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
+    void trace(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /** Returns {@code true} if the {@code debug} level is enabled. */
     boolean isDebugEnabled();
@@ -328,7 +334,7 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void debug(@CompileTimeConstant String message);
+    void debug(@Safe @CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -336,29 +342,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, @Nullable Throwable throwable);
+    void debug(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0);
-
-    /**
-     * Logs the provided parameters at {@code debug} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     * @param throwable Throwable to log with a stack trace
-     */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
-
-    /**
-     * Logs the provided parameters at {@code debug} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -366,14 +357,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -381,15 +372,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code debug} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -398,7 +388,27 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable);
+
+    /**
+     * Logs the provided parameters at {@code debug} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     */
+    void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+
+    /**
+     * Logs the provided parameters at {@code debug} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     * @param throwable Throwable to log with a stack trace
+     */
+    void debug(
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -410,7 +420,8 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
+    void debug(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -419,7 +430,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -433,7 +444,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -448,7 +459,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -463,7 +474,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -479,7 +490,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -495,7 +506,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -512,7 +523,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -529,7 +540,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -547,7 +558,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -565,7 +576,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -584,7 +595,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -603,7 +614,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args);
+    void debug(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args);
 
     /**
      * Logs the provided parameters at {@code debug} level.
@@ -612,7 +623,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
+    void debug(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /** Returns {@code true} if the {@code info} level is enabled. */
     boolean isInfoEnabled();
@@ -622,7 +633,7 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void info(@CompileTimeConstant String message);
+    void info(@Safe @CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -630,29 +641,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, @Nullable Throwable throwable);
+    void info(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0);
-
-    /**
-     * Logs the provided parameters at {@code info} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     * @param throwable Throwable to log with a stack trace
-     */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
-
-    /**
-     * Logs the provided parameters at {@code info} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -660,14 +656,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -675,15 +671,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code info} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -692,7 +687,27 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable);
+
+    /**
+     * Logs the provided parameters at {@code info} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     */
+    void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+
+    /**
+     * Logs the provided parameters at {@code info} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     * @param throwable Throwable to log with a stack trace
+     */
+    void info(
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -704,7 +719,8 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
+    void info(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -713,7 +729,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -727,7 +743,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -742,7 +758,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -757,7 +773,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -773,7 +789,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -789,7 +805,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -806,7 +822,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -823,7 +839,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -841,7 +857,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -859,7 +875,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -878,7 +894,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -897,7 +913,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    void info(@CompileTimeConstant String message, List<? extends Arg<?>> args);
+    void info(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args);
 
     /**
      * Logs the provided parameters at {@code info} level.
@@ -906,7 +922,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
+    void info(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /** Returns {@code true} if the {@code warn} level is enabled. */
     boolean isWarnEnabled();
@@ -916,7 +932,7 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void warn(@CompileTimeConstant String message);
+    void warn(@Safe @CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -924,29 +940,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, @Nullable Throwable throwable);
+    void warn(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0);
-
-    /**
-     * Logs the provided parameters at {@code warn} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     * @param throwable Throwable to log with a stack trace
-     */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
-
-    /**
-     * Logs the provided parameters at {@code warn} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -954,14 +955,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -969,15 +970,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code warn} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -986,7 +986,27 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable);
+
+    /**
+     * Logs the provided parameters at {@code warn} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     */
+    void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+
+    /**
+     * Logs the provided parameters at {@code warn} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     * @param throwable Throwable to log with a stack trace
+     */
+    void warn(
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -998,7 +1018,8 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
+    void warn(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1007,7 +1028,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1021,7 +1042,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1036,7 +1057,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1051,7 +1072,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1067,7 +1088,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1083,7 +1104,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1100,7 +1121,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1117,7 +1138,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1135,7 +1156,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1153,7 +1174,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1172,7 +1193,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1191,7 +1212,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args);
+    void warn(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args);
 
     /**
      * Logs the provided parameters at {@code warn} level.
@@ -1200,7 +1221,7 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
+    void warn(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 
     /** Returns {@code true} if the {@code error} level is enabled. */
     boolean isErrorEnabled();
@@ -1210,7 +1231,7 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void error(@CompileTimeConstant String message);
+    void error(@Safe @CompileTimeConstant String message);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1218,29 +1239,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, @Nullable Throwable throwable);
+    void error(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0);
-
-    /**
-     * Logs the provided parameters at {@code error} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     * @param throwable Throwable to log with a stack trace
-     */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
-
-    /**
-     * Logs the provided parameters at {@code error} level.
-     *
-     * @param message Message string to log, supports slf4j-style curly-brace interpolation
-     */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1248,14 +1254,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1263,15 +1269,14 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable);
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable);
 
     /**
      * Logs the provided parameters at {@code error} level.
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1280,7 +1285,27 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable);
+
+    /**
+     * Logs the provided parameters at {@code error} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     */
+    void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3);
+
+    /**
+     * Logs the provided parameters at {@code error} level.
+     *
+     * @param message Message string to log, supports slf4j-style curly-brace interpolation
+     * @param throwable Throwable to log with a stack trace
+     */
+    void error(
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1292,7 +1317,8 @@ public interface SafeLoggerBridge {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
+    void error(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1301,7 +1327,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1315,7 +1341,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1330,7 +1356,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1345,7 +1371,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1361,7 +1387,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1377,7 +1403,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1394,7 +1420,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1411,7 +1437,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1429,7 +1455,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1447,7 +1473,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1466,7 +1492,7 @@ public interface SafeLoggerBridge {
      * @param throwable Throwable to log with a stack trace
      */
     void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1485,7 +1511,7 @@ public interface SafeLoggerBridge {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    void error(@CompileTimeConstant String message, List<? extends Arg<?>> args);
+    void error(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args);
 
     /**
      * Logs the provided parameters at {@code error} level.
@@ -1494,5 +1520,5 @@ public interface SafeLoggerBridge {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
+    void error(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable);
 }

--- a/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
+++ b/logger/src/main/java/com/palantir/logsafe/logger/SafeLogger.java
@@ -15,6 +15,7 @@ package com.palantir.logsafe.logger;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.logger.spi.SafeLoggerBridge;
 import java.util.List;
 import java.util.Objects;
@@ -42,7 +43,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void trace(@CompileTimeConstant String message) {
+    public void trace(@Safe @CompileTimeConstant String message) {
         delegate.trace(message);
     }
 
@@ -52,7 +53,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.trace(message, throwable);
     }
 
@@ -61,7 +62,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.trace(message, arg0);
     }
 
@@ -71,7 +72,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.trace(message, arg0, throwable);
     }
 
@@ -80,7 +81,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.trace(message, arg0, arg1);
     }
 
@@ -90,7 +91,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, throwable);
     }
 
@@ -99,7 +101,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.trace(message, arg0, arg1, arg2);
     }
 
@@ -110,7 +112,11 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.trace(message, arg0, arg1, arg2, throwable);
     }
 
@@ -119,7 +125,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void trace(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void trace(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.trace(message, arg0, arg1, arg2, arg3);
     }
 
@@ -130,7 +136,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -145,7 +151,12 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.trace(message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -156,7 +167,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -172,7 +183,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -189,7 +200,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -206,7 +217,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -224,7 +235,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -242,7 +253,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -261,7 +272,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -280,7 +291,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -300,7 +311,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -320,7 +331,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -341,7 +352,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void trace(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -362,7 +373,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void trace(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         delegate.trace(message, args);
     }
 
@@ -373,7 +384,8 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void trace(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void trace(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.trace(message, args, throwable);
     }
 
@@ -387,7 +399,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void debug(@CompileTimeConstant String message) {
+    public void debug(@Safe @CompileTimeConstant String message) {
         delegate.debug(message);
     }
 
@@ -397,7 +409,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.debug(message, throwable);
     }
 
@@ -406,7 +418,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.debug(message, arg0);
     }
 
@@ -416,7 +428,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.debug(message, arg0, throwable);
     }
 
@@ -425,7 +437,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.debug(message, arg0, arg1);
     }
 
@@ -435,7 +447,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, throwable);
     }
 
@@ -444,7 +457,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.debug(message, arg0, arg1, arg2);
     }
 
@@ -455,7 +468,11 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.debug(message, arg0, arg1, arg2, throwable);
     }
 
@@ -464,7 +481,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void debug(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void debug(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.debug(message, arg0, arg1, arg2, arg3);
     }
 
@@ -475,7 +492,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -490,7 +507,12 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.debug(message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -501,7 +523,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -517,7 +539,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -534,7 +556,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -551,7 +573,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -569,7 +591,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -587,7 +609,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -606,7 +628,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -625,7 +647,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -645,7 +667,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -665,7 +687,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -686,7 +708,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void debug(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -707,7 +729,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void debug(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         delegate.debug(message, args);
     }
 
@@ -718,7 +740,8 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void debug(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void debug(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.debug(message, args, throwable);
     }
 
@@ -732,7 +755,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void info(@CompileTimeConstant String message) {
+    public void info(@Safe @CompileTimeConstant String message) {
         delegate.info(message);
     }
 
@@ -742,7 +765,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.info(message, throwable);
     }
 
@@ -751,7 +774,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.info(message, arg0);
     }
 
@@ -761,7 +784,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.info(message, arg0, throwable);
     }
 
@@ -770,7 +793,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.info(message, arg0, arg1);
     }
 
@@ -780,7 +803,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, throwable);
     }
 
@@ -789,7 +813,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.info(message, arg0, arg1, arg2);
     }
 
@@ -800,7 +824,11 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.info(message, arg0, arg1, arg2, throwable);
     }
 
@@ -809,7 +837,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void info(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void info(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.info(message, arg0, arg1, arg2, arg3);
     }
 
@@ -820,7 +848,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -835,7 +863,12 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.info(message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -846,7 +879,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -862,7 +895,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -879,7 +912,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -896,7 +929,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -914,7 +947,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -932,7 +965,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -951,7 +984,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -970,7 +1003,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -990,7 +1023,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1010,7 +1043,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1031,7 +1064,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void info(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1052,7 +1085,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void info(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         delegate.info(message, args);
     }
 
@@ -1063,7 +1096,8 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void info(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void info(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.info(message, args, throwable);
     }
 
@@ -1077,7 +1111,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void warn(@CompileTimeConstant String message) {
+    public void warn(@Safe @CompileTimeConstant String message) {
         delegate.warn(message);
     }
 
@@ -1087,7 +1121,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.warn(message, throwable);
     }
 
@@ -1096,7 +1130,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.warn(message, arg0);
     }
 
@@ -1106,7 +1140,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.warn(message, arg0, throwable);
     }
 
@@ -1115,7 +1149,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.warn(message, arg0, arg1);
     }
 
@@ -1125,7 +1159,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, throwable);
     }
 
@@ -1134,7 +1169,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.warn(message, arg0, arg1, arg2);
     }
 
@@ -1145,7 +1180,11 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.warn(message, arg0, arg1, arg2, throwable);
     }
 
@@ -1154,7 +1193,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void warn(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void warn(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.warn(message, arg0, arg1, arg2, arg3);
     }
 
@@ -1165,7 +1204,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1180,7 +1219,12 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.warn(message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -1191,7 +1235,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1207,7 +1251,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1224,7 +1268,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1241,7 +1285,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1259,7 +1303,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1277,7 +1321,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1296,7 +1340,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1315,7 +1359,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1335,7 +1379,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1355,7 +1399,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1376,7 +1420,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void warn(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1397,7 +1441,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void warn(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         delegate.warn(message, args);
     }
 
@@ -1408,7 +1452,8 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void warn(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void warn(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.warn(message, args, throwable);
     }
 
@@ -1422,7 +1467,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void error(@CompileTimeConstant String message) {
+    public void error(@Safe @CompileTimeConstant String message) {
         delegate.error(message);
     }
 
@@ -1432,7 +1477,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, @Nullable Throwable throwable) {
         delegate.error(message, throwable);
     }
 
@@ -1441,7 +1486,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0) {
         delegate.error(message, arg0);
     }
 
@@ -1451,7 +1496,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, @Nullable Throwable throwable) {
         delegate.error(message, arg0, throwable);
     }
 
@@ -1460,7 +1505,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1) {
         delegate.error(message, arg0, arg1);
     }
 
@@ -1470,7 +1515,8 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, throwable);
     }
 
@@ -1479,7 +1525,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2) {
         delegate.error(message, arg0, arg1, arg2);
     }
 
@@ -1490,7 +1536,11 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, @Nullable Throwable throwable) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            @Nullable Throwable throwable) {
         delegate.error(message, arg0, arg1, arg2, throwable);
     }
 
@@ -1499,7 +1549,7 @@ public final class SafeLogger {
      *
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
-    public void error(@CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+    public void error(@Safe @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         delegate.error(message, arg0, arg1, arg2, arg3);
     }
 
@@ -1510,7 +1560,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1525,7 +1575,12 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message, Arg<?> arg0, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3, Arg<?> arg4) {
+            @Safe @CompileTimeConstant String message,
+            Arg<?> arg0,
+            Arg<?> arg1,
+            Arg<?> arg2,
+            Arg<?> arg3,
+            Arg<?> arg4) {
         delegate.error(message, arg0, arg1, arg2, arg3, arg4);
     }
 
@@ -1536,7 +1591,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1552,7 +1607,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1569,7 +1624,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1586,7 +1641,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1604,7 +1659,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1622,7 +1677,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1641,7 +1696,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1660,7 +1715,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1680,7 +1735,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1700,7 +1755,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1721,7 +1776,7 @@ public final class SafeLogger {
      * @param throwable Throwable to log with a stack trace
      */
     public void error(
-            @CompileTimeConstant String message,
+            @Safe @CompileTimeConstant String message,
             Arg<?> arg0,
             Arg<?> arg1,
             Arg<?> arg2,
@@ -1742,7 +1797,7 @@ public final class SafeLogger {
      * @param message Message string to log, supports slf4j-style curly-brace interpolation
      * @param args List of safe-loggable arguments associated with this event
      */
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args) {
+    public void error(@Safe @CompileTimeConstant String message, List<? extends Arg<?>> args) {
         delegate.error(message, args);
     }
 
@@ -1753,7 +1808,8 @@ public final class SafeLogger {
      * @param args List of safe-loggable arguments associated with this event
      * @param throwable Throwable to log with a stack trace
      */
-    public void error(@CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
+    public void error(
+            @Safe @CompileTimeConstant String message, List<? extends Arg<?>> args, @Nullable Throwable throwable) {
         delegate.error(message, args, throwable);
     }
 }

--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -62,7 +62,7 @@ public final class Preconditions {
      * @throws SafeIllegalArgumentException if {@code expression} is false
      */
     @Contract("false, _ -> fail")
-    public static void checkArgument(boolean expression, @CompileTimeConstant String message) {
+    public static void checkArgument(boolean expression, @Safe @CompileTimeConstant String message) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message);
         }
@@ -74,7 +74,7 @@ public final class Preconditions {
      * <p>See {@link #checkArgument(boolean, String, Arg...)} for details.
      */
     @Contract("false, _, _ -> fail")
-    public static void checkArgument(boolean expression, @CompileTimeConstant String message, Arg<?> arg) {
+    public static void checkArgument(boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, arg);
         }
@@ -87,7 +87,7 @@ public final class Preconditions {
      */
     @Contract("false, _, _, _ -> fail")
     public static void checkArgument(
-            boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+            boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, arg1, arg2);
         }
@@ -100,7 +100,7 @@ public final class Preconditions {
      */
     @Contract("false, _, _, _, _ -> fail")
     public static void checkArgument(
-            boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+            boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, arg1, arg2, arg3);
         }
@@ -115,7 +115,7 @@ public final class Preconditions {
      * @throws SafeIllegalArgumentException if {@code expression} is false
      */
     @Contract("false, _, _ -> fail")
-    public static void checkArgument(boolean expression, @CompileTimeConstant String message, Arg<?>... args) {
+    public static void checkArgument(boolean expression, @Safe @CompileTimeConstant String message, Arg<?>... args) {
         if (!expression) {
             throw new SafeIllegalArgumentException(message, args);
         }
@@ -149,7 +149,7 @@ public final class Preconditions {
     @Nonnull
     @CanIgnoreReturnValue
     @Contract("null, _ -> fail; !null, _ -> param1")
-    public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message) {
+    public static <T> T checkArgumentNotNull(@Nullable T reference, @Safe @CompileTimeConstant String message) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message);
         }
@@ -164,7 +164,8 @@ public final class Preconditions {
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
-    public static <T> T checkArgumentNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
+    public static <T> T checkArgumentNotNull(
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message, arg);
         }
@@ -180,7 +181,7 @@ public final class Preconditions {
     @CanIgnoreReturnValue
     @Contract("null, _, _, _ -> fail; !null, _, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message, arg1, arg2);
         }
@@ -196,7 +197,7 @@ public final class Preconditions {
     @CanIgnoreReturnValue
     @Contract("null, _, _, _, _ -> fail; !null, _, _, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message, arg1, arg2, arg3);
         }
@@ -216,7 +217,7 @@ public final class Preconditions {
     @CanIgnoreReturnValue
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     public static <T> T checkArgumentNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?>... args) {
         if (reference == null) {
             throw new SafeIllegalArgumentException(message, args);
         }
@@ -246,7 +247,7 @@ public final class Preconditions {
      * @throws SafeIllegalStateException if {@code expression} is false
      */
     @Contract("false, _ -> fail")
-    public static void checkState(boolean expression, @CompileTimeConstant String message) {
+    public static void checkState(boolean expression, @Safe @CompileTimeConstant String message) {
         if (!expression) {
             throw new SafeIllegalStateException(message);
         }
@@ -258,7 +259,7 @@ public final class Preconditions {
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
     @Contract("false, _, _ -> fail")
-    public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?> arg) {
+    public static void checkState(boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg);
         }
@@ -270,7 +271,8 @@ public final class Preconditions {
      * <p>See {@link #checkState(boolean, String, Arg...)} for details.
      */
     @Contract("false, _, _, _ -> fail")
-    public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+    public static void checkState(
+            boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg1, arg2);
         }
@@ -283,7 +285,7 @@ public final class Preconditions {
      */
     @Contract("false, _, _, _, _ -> fail")
     public static void checkState(
-            boolean expression, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+            boolean expression, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (!expression) {
             throw new SafeIllegalStateException(message, arg1, arg2, arg3);
         }
@@ -299,7 +301,7 @@ public final class Preconditions {
      * @throws SafeIllegalStateException if {@code expression} is false
      */
     @Contract("false, _, _ -> fail")
-    public static void checkState(boolean expression, @CompileTimeConstant String message, Arg<?>... args) {
+    public static void checkState(boolean expression, @Safe @CompileTimeConstant String message, Arg<?>... args) {
         if (!expression) {
             throw new SafeIllegalStateException(message, args);
         }
@@ -333,7 +335,7 @@ public final class Preconditions {
     @Contract("null, _ -> fail; !null, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message) {
+    public static <T> T checkNotNull(@Nullable T reference, @Safe @CompileTimeConstant String message) {
         if (reference == null) {
             throw new SafeNullPointerException(message);
         }
@@ -348,7 +350,7 @@ public final class Preconditions {
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?> arg) {
+    public static <T> T checkNotNull(@Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg);
         }
@@ -364,7 +366,7 @@ public final class Preconditions {
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg1, arg2);
         }
@@ -380,7 +382,7 @@ public final class Preconditions {
     @Nonnull
     @CanIgnoreReturnValue
     public static <T> T checkNotNull(
-            @Nullable T reference, @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
         if (reference == null) {
             throw new SafeNullPointerException(message, arg1, arg2, arg3);
         }
@@ -399,7 +401,7 @@ public final class Preconditions {
     @Contract("null, _, _ -> fail; !null, _, _ -> param1")
     @Nonnull
     @CanIgnoreReturnValue
-    public static <T> T checkNotNull(@Nullable T reference, @CompileTimeConstant String message, Arg<?>... args) {
+    public static <T> T checkNotNull(@Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?>... args) {
         if (reference == null) {
             throw new SafeNullPointerException(message, args);
         }

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -18,13 +18,14 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import java.util.Arrays;
 
 /** {@link SafeExceptions} provides utility functionality for SafeLoggable exception implementations. */
 public final class SafeExceptions {
     private SafeExceptions() {}
 
-    public static String renderMessage(@CompileTimeConstant String safeMessage, Arg<?>... args) {
+    public static String renderMessage(@Safe @CompileTimeConstant String safeMessage, Arg<?>... args) {
         if (args == null || args.length == 0) {
             return safeMessage;
         }

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalArgumentException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,14 +35,14 @@ public final class SafeIllegalArgumentException extends IllegalArgumentException
         this.arguments = Collections.emptyList();
     }
 
-    public SafeIllegalArgumentException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIllegalArgumentException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
     public SafeIllegalArgumentException(
-            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
+            @Safe @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIllegalStateException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,14 +35,14 @@ public final class SafeIllegalStateException extends IllegalStateException imple
         this.arguments = Collections.emptyList();
     }
 
-    public SafeIllegalStateException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIllegalStateException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
     public SafeIllegalStateException(
-            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
+            @Safe @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeIoException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.io.IOException;
 import java.util.Arrays;
@@ -29,13 +30,13 @@ public final class SafeIoException extends IOException implements SafeLoggable {
     private final String logMessage;
     private final List<Arg<?>> arguments;
 
-    public SafeIoException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeIoException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeIoException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
+    public SafeIoException(@Safe @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeNullPointerException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeNullPointerException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +34,7 @@ public final class SafeNullPointerException extends NullPointerException impleme
         this.arguments = Collections.emptyList();
     }
 
-    public SafeNullPointerException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeNullPointerException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeRuntimeException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,13 +35,14 @@ public final class SafeRuntimeException extends RuntimeException implements Safe
         this.arguments = Collections.emptyList();
     }
 
-    public SafeRuntimeException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeRuntimeException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
-    public SafeRuntimeException(@CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
+    public SafeRuntimeException(
+            @Safe @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUncheckedIoException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -31,7 +32,7 @@ public final class SafeUncheckedIoException extends UncheckedIOException impleme
     private final List<Arg<?>> arguments;
 
     public SafeUncheckedIoException(
-            @CompileTimeConstant String message, @Nullable IOException cause, Arg<?>... arguments) {
+            @Safe @CompileTimeConstant String message, @Nullable IOException cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeUnsupportedOperationException.java
@@ -18,6 +18,7 @@ package com.palantir.logsafe.exceptions;
 
 import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeLoggable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,14 +35,14 @@ public final class SafeUnsupportedOperationException extends UnsupportedOperatio
         this.arguments = Collections.emptyList();
     }
 
-    public SafeUnsupportedOperationException(@CompileTimeConstant String message, Arg<?>... arguments) {
+    public SafeUnsupportedOperationException(@Safe @CompileTimeConstant String message, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments));
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));
     }
 
     public SafeUnsupportedOperationException(
-            @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
+            @Safe @CompileTimeConstant String message, @Nullable Throwable cause, Arg<?>... arguments) {
         super(SafeExceptions.renderMessage(message, arguments), cause);
         this.logMessage = message;
         this.arguments = Collections.unmodifiableList(Arrays.asList(arguments));


### PR DESCRIPTION
## Before this PR
All `@CompileTimeConstant` usage is strictly also `@Safe` implicitly. However according to @carterkozak in regards to an internal PR with a similar shaped set of `Exceptions`:

> Slight preference to include `@Safe` here as well. This way if somebody relaxes the compile-time-constant constraint, we don't lose safety validation as well.

One might think why wasn't this done in the original implemenation? To quote @carterkozak again:

> Those exceptions were implemented before we allowed safety annotations on fields

## After this PR
The safety invariant is now made explicit should there be changes in the future regarding our usage of `@CompileTimeConstant`.

