### PR TITLE
add Preconditions.checkStateNotNull

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/Preconditions.java
@@ -124,7 +124,7 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
      * @return the non-null reference that was validated
      * @throws SafeIllegalArgumentException if {@code reference} is null
      */
@@ -141,7 +141,7 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
      * @param message   the loggable exception message
      * @return the non-null reference that was validated
      * @throws SafeIllegalArgumentException if {@code reference} is null
@@ -207,7 +207,7 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
      * @param message   the loggable exception message
      * @param args      the arguments to include in the {@link SafeIllegalArgumentException}
      * @return the non-null reference that was validated
@@ -310,7 +310,110 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalStateException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null -> fail; !null -> param1")
+    public static <T> T checkStateNotNull(@Nullable T reference) {
+        if (reference == null) {
+            throw new SafeIllegalStateException();
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference a String reference
+     * @param message   the loggable exception message
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalStateException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null, _ -> fail; !null, _ -> param1")
+    public static <T> T checkStateNotNull(@Nullable T reference, @Safe @CompileTimeConstant String message) {
+        if (reference == null) {
+            throw new SafeIllegalStateException(message);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkStateNotNull(Object, String, Arg...)} for details.
+     */
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
+    @Nonnull
+    @CanIgnoreReturnValue
+    public static <T> T checkStateNotNull(
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg) {
+        if (reference == null) {
+            throw new SafeIllegalStateException(message, arg);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkStateNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null, _, _, _ -> fail; !null, _, _, _ -> param1")
+    public static <T> T checkStateNotNull(
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2) {
+        if (reference == null) {
+            throw new SafeIllegalStateException(message, arg1, arg2);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * <p>See {@link #checkStateNotNull(Object, String, Arg...)} for details.
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null, _, _, _, _ -> fail; !null, _, _, _, _ -> param1")
+    public static <T> T checkStateNotNull(
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?> arg1, Arg<?> arg2, Arg<?> arg3) {
+        if (reference == null) {
+            throw new SafeIllegalStateException(message, arg1, arg2, arg3);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference a String reference
+     * @param message   the loggable exception message
+     * @param args      the arguments to include in the {@link SafeIllegalStateException}
+     * @return the non-null reference that was validated
+     * @throws SafeIllegalStateException if {@code reference} is null
+     */
+    @Nonnull
+    @CanIgnoreReturnValue
+    @Contract("null, _, _ -> fail; !null, _, _ -> param1")
+    public static <T> T checkStateNotNull(
+            @Nullable T reference, @Safe @CompileTimeConstant String message, Arg<?>... args) {
+        if (reference == null) {
+            throw new SafeIllegalStateException(message, args);
+        }
+        return reference;
+    }
+
+    /**
+     * Ensures that an Object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference a String reference
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
      */
@@ -327,7 +430,7 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
      * @param message   the loggable exception message
      * @return the non-null reference that was validated
      * @throws SafeNullPointerException if {@code reference} is null
@@ -392,7 +495,7 @@ public final class Preconditions {
     /**
      * Ensures that an Object reference passed as a parameter to the calling method is not null.
      *
-     * @param reference an String reference
+     * @param reference a String reference
      * @param message   the loggable exception message
      * @param args      the arguments to include in the {@link SafeNullPointerException}
      * @return the non-null reference that was validated


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
there is no way to check an argument is not null with logsafe#Preconditions and throw a SafeIllegalState exception rather than SafeIllegalArgument or SafeNullPointer. this could be useful in code when an intermediate nullable state needs to be checked.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add Preconditions.checkStateNotNull
==COMMIT_MSG==

it's essentially the same as checkArgumentNotNull, just throws SafeIllegalStateException instead of SafeIllegalArgument. i believe this is better since SafeIllegalArgument suggests that the argument to a request is incorrect, whereas SafeIllegalState can be used to catch bugs caused by correctness issues.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

