### PR TITLE
Add list variant of SafeExceptions.renderMessage

### DIFF
--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -20,6 +20,7 @@ import com.google.errorprone.annotations.CompileTimeConstant;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.Safe;
 import java.util.Arrays;
+import java.util.List;
 
 /** {@link SafeExceptions} provides utility functionality for SafeLoggable exception implementations. */
 public final class SafeExceptions {
@@ -27,6 +28,31 @@ public final class SafeExceptions {
 
     public static String renderMessage(@Safe @CompileTimeConstant String safeMessage, Arg<?>... args) {
         if (args == null || args.length == 0) {
+            return safeMessage;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(safeMessage).append(": {");
+        boolean first = true;
+        for (Arg<?> arg : args) {
+            if (arg != null) {
+                if (!first) {
+                    builder.append(", ");
+                } else {
+                    first = false;
+                }
+
+                builder.append(arg.getName()).append("=");
+                appendValue(builder, arg);
+            }
+        }
+        builder.append('}');
+
+        return builder.toString();
+    }
+
+    public static String renderMessage(@Safe @CompileTimeConstant String safeMessage, List<Arg<?>> args) {
+        if (args == null || args.isEmpty()) {
             return safeMessage;
         }
 

--- a/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
+++ b/preconditions/src/main/java/com/palantir/logsafe/exceptions/SafeExceptions.java
@@ -55,25 +55,7 @@ public final class SafeExceptions {
         if (args == null || args.isEmpty()) {
             return safeMessage;
         }
-
-        StringBuilder builder = new StringBuilder();
-        builder.append(safeMessage).append(": {");
-        boolean first = true;
-        for (Arg<?> arg : args) {
-            if (arg != null) {
-                if (!first) {
-                    builder.append(", ");
-                } else {
-                    first = false;
-                }
-
-                builder.append(arg.getName()).append("=");
-                appendValue(builder, arg);
-            }
-        }
-        builder.append('}');
-
-        return builder.toString();
+        return renderMessage(safeMessage, args.toArray(Arg[]::new));
     }
 
     private static void appendValue(StringBuilder builder, Arg<?> arg) {

--- a/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionsTest.java
+++ b/preconditions/src/test/java/com/palantir/logsafe/exceptions/SafeExceptionsTest.java
@@ -20,6 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.logsafe.Arg;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.UnsafeArg;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public final class SafeExceptionsTest {
@@ -39,6 +42,32 @@ public final class SafeExceptionsTest {
     @Test
     public void testRenderNullMessage() {
         String rendered = SafeExceptions.renderMessage(null, SafeArg.of("a", "b"));
+        assertThat(rendered).isEqualTo("null: {a=b}");
+    }
+
+    @Test
+    public void testRenderListContainsNullArg() {
+        List<Arg<?>> args = Arrays.asList(SafeArg.of("a", "b"), null, UnsafeArg.of("c", "d"));
+        String rendered = SafeExceptions.renderMessage("test", args);
+        assertThat(rendered).isEqualTo("test: {a=b, c=d}");
+    }
+
+    @Test
+    public void testRenderNullList() {
+        String rendered = SafeExceptions.renderMessage("test", (List<Arg<?>>) null);
+        assertThat(rendered).isEqualTo("test");
+    }
+
+    @Test
+    public void testRenderEmptyList() {
+        String rendered = SafeExceptions.renderMessage("test", Collections.emptyList());
+        assertThat(rendered).isEqualTo("test");
+    }
+
+    @Test
+    public void testRenderListNullMessage() {
+        List<Arg<?>> args = Arrays.asList(SafeArg.of("a", "b"));
+        String rendered = SafeExceptions.renderMessage(null, args);
         assertThat(rendered).isEqualTo("null: {a=b}");
     }
 }


### PR DESCRIPTION
## Before this PR
When creating custom SafeLoggable exceptions, it's common to take specific named args in the exception constructor. However, that pattern isn't very amenable to the varargs version of renderMessage, because the other code for constructing the message args will return a list.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add list variant of SafeExceptions.renderMessage
==COMMIT_MSG==

I'm expecting to use this either as
```java
class MyException extends RuntimeException implements SafeLoggable {
    private final List<Arg<?>> args;
    public MyException(long param) {
        this(List.of(SafeArg.of("param", param)));
    }
    private MyException(List<Arg<?>> args) {
        super(SafeExceptions.renderMessage("...", args));
        this.args = args;
    }
    @Override public List<Arg<?>> getArgs() {
        return args;
    }
}
```
or
```java
class MyException extends RuntimeException implements SafeLoggable {
    private final long param;
    public MyException(long param) {
        super(SafeExceptions.renderMessage("...", renderArgs(param)));
        this.param = param;
    }
    @Override public List<Arg<?>> getArgs() {
        return renderArgs(param);
    }
    private static List<Arg<?>> renderArgs(long param) {
        return List.of(SafeArg.of("param", param));
    }
}
```

## Possible downsides?
It's still not the cleanest example code. Java 25 flexible constructor bodies should make the examples even nicer, once that's available widely enough.

Written by 🤖 claude.