### PR TITLE
Avoid ServiceLoader.stream() for Java 8 / Android desugaring compatibility

### DIFF
--- a/logger/src/main/java/com/palantir/logsafe/logger/SafeLoggerFactory.java
+++ b/logger/src/main/java/com/palantir/logsafe/logger/SafeLoggerFactory.java
@@ -24,16 +24,21 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
 
 /** Factory used to access {@link SafeLogger} instance. */
 public final class SafeLoggerFactory {
 
-    private static final SafeLoggerFactoryBridge BRIDGE =
-            ServiceLoader.load(SafeLoggerFactoryBridge.class, SafeLoggerFactory.class.getClassLoader()).stream()
-                    .map(ServiceLoader.Provider::get)
-                    .max(Comparator.comparing(SafeLoggerFactoryBridge::priority))
-                    // Should never happen unless dependencies are explicitly excluded
-                    .orElseThrow(NoSafeLoggerImplementationsException::new);
+    private static final SafeLoggerFactoryBridge BRIDGE = findBridge();
+
+    private static SafeLoggerFactoryBridge findBridge() {
+        ServiceLoader<SafeLoggerFactoryBridge> loader =
+                ServiceLoader.load(SafeLoggerFactoryBridge.class, SafeLoggerFactory.class.getClassLoader());
+        return StreamSupport.stream(loader.spliterator(), false)
+                .max(Comparator.comparing(SafeLoggerFactoryBridge::priority))
+                // Should never happen unless dependencies are explicitly excluded
+                .orElseThrow(NoSafeLoggerImplementationsException::new);
+    }
 
     /** Returns a {@link SafeLogger} for the {@code clazz} origin. */
     public static SafeLogger get(@Safe Class<?> clazz) {


### PR DESCRIPTION
## Before this PR
SafeLoggerFactory creates its SafeLoggerFactoryBridge by using ServiceLoader.stream() which is a Java 9 API. This will result in a NoSuchMethodError getting thrown at runtime on Android devices using the logger at lower API levels. (e.g. API 29/ Android 10).


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
ServiceLoader iteration adapted to use StreamSupport for Java 8 / Android desugaring compatibility
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None, behavior is identical.

